### PR TITLE
fix: serialize agy subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Serialized `agy` subprocesses across bridge instances to prevent concurrent model discovery and prompt failures.
+
 ## [1.0.0] - 2026-06-29
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -7,8 +7,15 @@ import pkg from "./package.json";
 import { runAcp } from "./src/acp/server";
 import { downloadedAgyPath } from "./src/agy/binary";
 import { ensureAgy } from "./src/agy/installer";
+import { AGY_PROCESS_PROXY_FLAG, runAgyProcessProxy } from "./src/agy/process";
 
 async function main(): Promise<void> {
+	const proxyFlagIndex = process.argv.indexOf(AGY_PROCESS_PROXY_FLAG);
+	if (proxyFlagIndex !== -1) {
+		const encodedRequest = process.argv[proxyFlagIndex + 1];
+		process.exit(await runAgyProcessProxy(encodedRequest));
+	}
+
 	if (process.argv.includes("--version") || process.argv.includes("-v")) {
 		process.stdout.write(`${pkg.version}\n`);
 		process.exit(0);

--- a/src/acp/adapter.ts
+++ b/src/acp/adapter.ts
@@ -2,7 +2,13 @@
 // the client, and finalize. Bridges the agy subprocess and the conversation
 // streaming layer.
 
-import { buildAgyArgs, extraArgsFromEnv, spawnAgy } from "../agy/process";
+import {
+	AgyProcessCancelledError,
+	type AgySubprocess,
+	buildAgyArgs,
+	extraArgsFromEnv,
+	spawnAgy,
+} from "../agy/process";
 import { POLL_INTERVAL_MS } from "../constants";
 import { conversationSnapshot } from "../conversation/scan";
 import { StreamPoller } from "../conversation/streaming";
@@ -28,14 +34,12 @@ export interface AdapterConfig {
 }
 
 export class Adapter {
-	private readonly children = new Map<string, Bun.Subprocess>();
-	private readonly cancelled = new Set<string>();
+	private readonly children = new Map<string, AgySubprocess>();
 
 	constructor(private readonly config: AdapterConfig) {}
 
 	/** Request cancellation of an in-flight prompt for a session. */
 	cancel(sessionId: string): void {
-		this.cancelled.add(sessionId);
 		const child = this.children.get(sessionId);
 		if (child) {
 			// SIGINT allows agy to flush its DB before exiting; on Windows we fall
@@ -54,17 +58,23 @@ export class Adapter {
 		session: Session,
 		promptText: string,
 		client: AcpClient,
+		signal?: AbortSignal,
 	): Promise<PromptOutcome> {
-		this.cancelled.delete(sessionId);
+		if (signal?.aborted) {
+			return {
+				stopReason: "cancelled",
+				conversationId: session.conversationId,
+				lastStepIdx: session.lastStepIdx,
+				hadUpdates: false,
+			};
+		}
 
 		// Use the session's cwd if set, otherwise fall back to the server's workingDir.
 		const effectiveCwd = session.cwd || this.config.workingDir;
 
-		// Snapshot existing conversations so we can bind the new DB agy creates.
-		const snapshot =
-			session.conversationId === null
-				? conversationSnapshot(this.config.conversationsDir)
-				: null;
+		// Snapshot existing conversations while this prompt owns the global agy
+		// process lock, immediately before the child starts.
+		let snapshot: Set<string> | null = null;
 
 		const args = buildAgyArgs({
 			workingDir: effectiveCwd,
@@ -76,10 +86,28 @@ export class Adapter {
 			extraArgs: extraArgsFromEnv(),
 		});
 
-		let child: Bun.Subprocess;
+		let child: AgySubprocess;
 		try {
-			child = spawnAgy(this.config.binary, args, effectiveCwd);
+			child = await spawnAgy(
+				this.config.binary,
+				args,
+				effectiveCwd,
+				signal,
+				() => {
+					if (session.conversationId === null) {
+						snapshot = conversationSnapshot(this.config.conversationsDir);
+					}
+				},
+			);
 		} catch (err) {
+			if (signal?.aborted || err instanceof AgyProcessCancelledError) {
+				return {
+					stopReason: "cancelled",
+					conversationId: session.conversationId,
+					lastStepIdx: session.lastStepIdx,
+					hadUpdates: false,
+				};
+			}
 			return {
 				stopReason: "end_turn",
 				conversationId: session.conversationId,
@@ -89,6 +117,7 @@ export class Adapter {
 			};
 		}
 		this.children.set(sessionId, child);
+		if (signal?.aborted) this.cancel(sessionId);
 
 		// Drain stderr concurrently (resolves when the process exits).
 		const stderrPromise = child.stderr
@@ -143,7 +172,7 @@ export class Adapter {
 		const stderr = (await stderrPromise).trim();
 		if (stderr.length > 0) console.error(`[agy-acp] agy stderr: ${stderr}`);
 
-		const wasCancelled = this.cancelled.delete(sessionId);
+		const wasCancelled = signal?.aborted ?? false;
 
 		const outcome: PromptOutcome = {
 			stopReason: wasCancelled ? "cancelled" : "end_turn",

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -51,13 +51,39 @@ interface ConfigResult {
 	configOptions: SessionConfigOption[];
 }
 
+function waitUnlessCancelled(
+	promise: Promise<void>,
+	signal: AbortSignal,
+): Promise<boolean> {
+	if (signal.aborted) return Promise.resolve(false);
+	return new Promise((resolve, reject) => {
+		const onAbort = () => {
+			signal.removeEventListener("abort", onAbort);
+			resolve(false);
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		void promise.then(
+			() => {
+				signal.removeEventListener("abort", onAbort);
+				resolve(true);
+			},
+			(error: unknown) => {
+				signal.removeEventListener("abort", onAbort);
+				reject(error);
+			},
+		);
+	});
+}
+
 export class AgyAcpAgent {
 	private readonly sessions: SessionManager;
 	private readonly adapter: Adapter;
 	private readonly replayCache = new ReplayCache();
 	private availableModels: string[] = [];
+	private readonly modelDiscovery: Promise<void>;
 	// Tracks which AcpClient is serving each session so async updates can be pushed.
 	private readonly activeClients = new Map<string, AcpClient>();
+	private readonly promptControllers = new Map<string, AbortController>();
 
 	constructor(private readonly config: AgentConfig) {
 		this.sessions = new SessionManager(new SessionStore());
@@ -81,7 +107,7 @@ export class AgyAcpAgent {
 
 		// Kick off model discovery in the background; update cache and push
 		// config_option_update to all active sessions if the list changes.
-		discoverModels(config.binary).then((models) => {
+		this.modelDiscovery = discoverModels(config.binary).then((models) => {
 			const changed =
 				JSON.stringify(models) !== JSON.stringify(this.availableModels);
 			if (changed && models.length > 0) {
@@ -251,6 +277,7 @@ export class AgyAcpAgent {
 	closeSession(params: { sessionId?: string }): CloseSessionResponse {
 		const sessionId = params.sessionId;
 		if (sessionId) {
+			this.promptControllers.get(sessionId)?.abort();
 			this.adapter.cancel(sessionId);
 			this.sessions.evict(sessionId);
 			this.activeClients.delete(sessionId);
@@ -263,43 +290,60 @@ export class AgyAcpAgent {
 		client: AcpClient,
 	): Promise<PromptResponse> {
 		const sessionId = this.requireSessionId(params.sessionId);
+		const controller = new AbortController();
+		this.promptControllers.set(sessionId, controller);
 
-		let session = await this.sessions.ensure(sessionId);
-		if (!session) {
-			// Unknown session: create a fresh binding so prompts still work.
-			session = newSession(this.config.workingDir);
-			this.sessions.adopt(sessionId, session);
+		try {
+			let session = await this.sessions.ensure(sessionId);
+			if (!session) {
+				// Unknown session: create a fresh binding so prompts still work.
+				session = newSession(this.config.workingDir);
+				this.sessions.adopt(sessionId, session);
+			}
+
+			const rawText = promptText(params.prompt);
+			const text =
+				session.permissionMode === PLAN_MODE_ID
+					? PLAN_MODE_INJECTION + rawText
+					: rawText;
+			if (
+				!(await waitUnlessCancelled(this.modelDiscovery, controller.signal))
+			) {
+				return { stopReason: "cancelled" };
+			}
+			const outcome = await this.adapter.runPrompt(
+				sessionId,
+				session,
+				text,
+				client,
+				controller.signal,
+			);
+
+			if (outcome.error)
+				throw RequestError.internalError(undefined, outcome.error);
+
+			if (session.conversationId === null) {
+				session.conversationId = outcome.conversationId;
+			}
+			if (outcome.conversationId !== null) {
+				session.lastStepIdx = outcome.lastStepIdx;
+				session.updatedAt = new Date().toISOString();
+				await this.sessions.persist(sessionId, session);
+			}
+
+			return { stopReason: outcome.stopReason };
+		} finally {
+			if (this.promptControllers.get(sessionId) === controller) {
+				this.promptControllers.delete(sessionId);
+			}
 		}
-
-		const rawText = promptText(params.prompt);
-		const text =
-			session.permissionMode === PLAN_MODE_ID
-				? PLAN_MODE_INJECTION + rawText
-				: rawText;
-		const outcome = await this.adapter.runPrompt(
-			sessionId,
-			session,
-			text,
-			client,
-		);
-
-		if (outcome.error)
-			throw RequestError.internalError(undefined, outcome.error);
-
-		if (session.conversationId === null) {
-			session.conversationId = outcome.conversationId;
-		}
-		if (outcome.conversationId !== null) {
-			session.lastStepIdx = outcome.lastStepIdx;
-			session.updatedAt = new Date().toISOString();
-			await this.sessions.persist(sessionId, session);
-		}
-
-		return { stopReason: outcome.stopReason };
 	}
 
 	cancel(params: { sessionId?: string }): void {
-		if (params.sessionId) this.adapter.cancel(params.sessionId);
+		if (params.sessionId) {
+			this.promptControllers.get(params.sessionId)?.abort();
+			this.adapter.cancel(params.sessionId);
+		}
 	}
 
 	/** SDK-native config setter (session/set_config_option). */

--- a/src/agy/process.ts
+++ b/src/agy/process.ts
@@ -10,6 +10,9 @@ import { STATE_DIR } from "../constants";
 
 const BYPASS_MODES = new Set(["bypassPermissions", "bypass", "dontAsk"]);
 const LOCK_POLL_INTERVAL_MS = 50;
+const DEFAULT_HANDSHAKE_TIMEOUT_MS = 30_000;
+/** Exit code the proxy uses when it cancels instead of launching agy. */
+const PROXY_CANCELLED_EXIT_CODE = 130;
 export const AGY_PROCESS_PROXY_FLAG = "--internal-agy-process-proxy";
 const AGY_PROCESS_PROXY_READY_FD = "AGY_ACP_PROCESS_PROXY_READY_FD";
 const AGY_PROCESS_PROXY_CONTROL_FD = "AGY_ACP_PROCESS_PROXY_CONTROL_FD";
@@ -269,10 +272,11 @@ export async function runAgyProcessProxy(encoded?: string): Promise<number> {
 			try {
 				fs.writeSync(handshake.ready, "locked\n");
 			} catch {
-				return 130;
+				return PROXY_CANCELLED_EXIT_CODE;
 			}
 			const command = await firstCommand;
-			if (command === null || command === "cancel") return 130;
+			if (command === null || command === "cancel")
+				return PROXY_CANCELLED_EXIT_CODE;
 			if (command !== "start") {
 				throw new Error("invalid agy process proxy command");
 			}
@@ -308,7 +312,8 @@ export async function runAgyProcessProxy(encoded?: string): Promise<number> {
 		}
 		return await child.exited;
 	} catch (error) {
-		if (error instanceof AgyProcessCancelledError) return 130;
+		if (error instanceof AgyProcessCancelledError)
+			return PROXY_CANCELLED_EXIT_CODE;
 		throw error;
 	} finally {
 		release?.();
@@ -370,9 +375,129 @@ export function buildAgyArgs(opts: AgyArgsOptions): string[] {
 	return args;
 }
 
+function handshakeTimeoutMs(): number {
+	const raw = Number(process.env.AGY_ACP_HANDSHAKE_TIMEOUT_MS);
+	return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_HANDSHAKE_TIMEOUT_MS;
+}
+
+/** How long to keep reading the ready pipe after the proxy exits, so a signal
+ *  written immediately before exit is still picked up. */
+const HANDSHAKE_EXIT_GRACE_MS = 250;
+
+const HANDSHAKE_EXITED = Symbol("handshake-exited");
+const HANDSHAKE_TIMED_OUT = Symbol("handshake-timed-out");
+const HANDSHAKE_PIPE_FAILED = Symbol("handshake-pipe-failed");
+
+/** Attempts allowed when the handshake pipes themselves fail to come up. */
+const MAX_HANDSHAKE_ATTEMPTS = 3;
+
+function afterDelay<T>(ms: number, value: T): [Promise<T>, () => void] {
+	let timer: ReturnType<typeof setTimeout>;
+	const promise = new Promise<T>((resolve) => {
+		timer = setTimeout(() => resolve(value), ms);
+	});
+	return [promise, () => clearTimeout(timer)];
+}
+
+/** Await the next handshake line, but give up if the proxy exits or the
+ *  deadline passes instead of waiting on a pipe that may never reach EOF. */
+async function raceHandshake(
+	next: Promise<IteratorResult<string>>,
+	exited: Promise<number>,
+	pipeFailed: Promise<Error>,
+	expected: string,
+	timeoutMs?: number,
+): Promise<IteratorResult<string>> {
+	const contenders: Promise<
+		| IteratorResult<string>
+		| typeof HANDSHAKE_EXITED
+		| typeof HANDSHAKE_TIMED_OUT
+		| typeof HANDSHAKE_PIPE_FAILED
+	>[] = [
+		next,
+		exited.then(
+			() => HANDSHAKE_EXITED,
+			() => HANDSHAKE_EXITED,
+		),
+		pipeFailed.then(() => HANDSHAKE_PIPE_FAILED),
+	];
+	const [deadline, cancelDeadline] =
+		timeoutMs === undefined
+			? [undefined, () => {}]
+			: afterDelay(timeoutMs, HANDSHAKE_TIMED_OUT);
+	if (deadline) contenders.push(deadline);
+
+	try {
+		const outcome = await Promise.race(contenders);
+		if (outcome === HANDSHAKE_TIMED_OUT) {
+			throw new Error(
+				`timed out waiting for agy process proxy ${expected} signal`,
+			);
+		}
+		if (outcome === HANDSHAKE_PIPE_FAILED) {
+			// startAgyProxy turns this into a retryable AgyProxyPipeError.
+			throw await pipeFailed;
+		}
+		if (outcome !== HANDSHAKE_EXITED) return outcome;
+
+		const [grace, cancelGrace] = afterDelay(
+			HANDSHAKE_EXIT_GRACE_MS,
+			HANDSHAKE_EXITED,
+		);
+		try {
+			const flushed = await Promise.race([next, grace]);
+			if (flushed === HANDSHAKE_EXITED) {
+				const code = await exited.catch(() => "error");
+				throw new Error(
+					`agy process proxy exited (code ${code}) before the ${expected} signal`,
+				);
+			}
+			return flushed;
+		} finally {
+			cancelGrace();
+		}
+	} finally {
+		cancelDeadline();
+	}
+}
+
+/** The handshake pipes failed to come up on the bridge side, so the attempt
+ *  never reached agy and is safe to retry. */
+class AgyProxyPipeError extends Error {
+	constructor(cause: Error) {
+		super(`agy process proxy handshake pipe failed: ${cause.message}`);
+		this.name = "AgyProxyPipeError";
+		this.cause = cause;
+	}
+}
+
 /** Spawn agy for a prompt. stdout is ignored (agy persists to its DB); stderr is
- *  piped so the caller can surface failures. */
+ *  piped so the caller can surface failures.
+ *
+ *  The extra stdio pipes carrying the handshake occasionally fail to connect on
+ *  the bridge side under load; the proxy then reads EOF on its control pipe,
+ *  takes that for "the bridge exited" and cancels itself. Nothing has run at
+ *  that point, so retry rather than surfacing a spurious failure. */
 export async function spawnAgy(
+	binary: string,
+	args: string[],
+	cwd: string,
+	signal?: AbortSignal,
+	onLockAcquired?: () => void,
+): Promise<AgySubprocess> {
+	let lastError: AgyProxyPipeError | undefined;
+	for (let attempt = 0; attempt < MAX_HANDSHAKE_ATTEMPTS; attempt++) {
+		try {
+			return await startAgyProxy(binary, args, cwd, signal, onLockAcquired);
+		} catch (error) {
+			if (!(error instanceof AgyProxyPipeError)) throw error;
+			lastError = error;
+		}
+	}
+	throw lastError;
+}
+
+async function startAgyProxy(
 	binary: string,
 	args: string[],
 	cwd: string,
@@ -444,11 +569,41 @@ export async function spawnAgy(
 		subprocess.kill();
 		throw new Error("agy process proxy handshake pipe unavailable");
 	}
+	// A failed pipe emits "error" rather than ever delivering a signal; record it
+	// so the handshake can abandon this attempt immediately (and so the event
+	// does not go unhandled).
+	let pipeError: Error | undefined;
+	let notePipeError: (error: Error) => void = (error) => {
+		pipeError ??= error;
+	};
+	const pipeFailed = new Promise<Error>((resolve) => {
+		notePipeError = (error) => {
+			pipeError ??= error;
+			resolve(pipeError);
+		};
+	});
+	readyStream.on("error", notePipeError);
+	controlStream.on("error", notePipeError);
+	requestStream.on("error", notePipeError);
+
 	requestStream.end(JSON.stringify(request));
 	const lines = createInterface({ input: readyStream });
 	const iterator = lines[Symbol.asyncIterator]();
-	const waitForMessage = async (expected: string): Promise<void> => {
-		const message = await iterator.next();
+	// The proxy's exit closes its copy of the ready pipe, but a lost EOF would
+	// otherwise leave the handshake waiting forever — race exit and, for signals
+	// that are supposed to be prompt, a deadline.
+	const waitForMessage = async (
+		expected: string,
+		timeoutMs?: number,
+	): Promise<void> => {
+		const next = iterator.next();
+		const message = await raceHandshake(
+			next,
+			exited,
+			pipeFailed,
+			expected,
+			timeoutMs,
+		);
 		if (!message.done && message.value.startsWith("error:")) {
 			const encodedError = message.value.slice("error:".length);
 			throw new Error(Buffer.from(encodedError, "base64url").toString("utf8"));
@@ -458,17 +613,43 @@ export async function spawnAgy(
 		}
 	};
 	try {
+		// No deadline on "locked": queueing behind another agy run is unbounded.
 		await waitForMessage("locked");
 		throwIfCancelled(signal);
 		onLockAcquired?.();
 		controlStream.write("start\n");
-		await waitForMessage("ready");
+		await waitForMessage("ready", handshakeTimeoutMs());
 		lines.close();
 		throwIfCancelled(signal);
 	} catch (error) {
 		lines.close();
+		// The handshake never completed, so there is no agy child to shut down
+		// gracefully — terminate the proxy directly rather than asking over an IPC
+		// channel it has already proven unresponsive on.
+		child.kill();
 		if (signal?.aborted) throw new AgyProcessCancelledError();
-		subprocess.kill();
+		if (!pipeError) {
+			// A dying pipe can surface as a silent end-of-stream a tick before it
+			// emits "error"; give it that tick so the failure stays retryable.
+			const [tick, cancelTick] = afterDelay(0, undefined);
+			await Promise.race([pipeFailed, tick]);
+			cancelTick();
+		}
+		if (pipeError) throw new AgyProxyPipeError(pipeError);
+		// The proxy cancels itself when its control pipe reports EOF, which it
+		// reads as "the bridge exited". If we never asked it to cancel and are
+		// still here to see it, that EOF was spurious: the pipe broke rather than
+		// the bridge dying. Nothing has run yet, so let the caller retry.
+		if (!cancelSent && !signal?.aborted) {
+			const [tick, cancelTick] = afterDelay(50, undefined);
+			const code = await Promise.race([exited.catch(() => undefined), tick]);
+			cancelTick();
+			if (code === PROXY_CANCELLED_EXIT_CODE) {
+				throw new AgyProxyPipeError(
+					new Error("proxy cancelled itself during the handshake"),
+				);
+			}
+		}
 		throw error;
 	}
 	return subprocess;

--- a/src/agy/process.ts
+++ b/src/agy/process.ts
@@ -266,9 +266,13 @@ export async function runAgyProcessProxy(encoded?: string): Promise<number> {
 		release = await acquireAgyProcessLock(controller.signal);
 		throwIfCancelled(controller.signal);
 		if (handshake && firstCommand) {
-			fs.writeSync(handshake.ready, "locked\n");
+			try {
+				fs.writeSync(handshake.ready, "locked\n");
+			} catch {
+				return 130;
+			}
 			const command = await firstCommand;
-			if (command === "cancel") return 130;
+			if (command === null || command === "cancel") return 130;
 			if (command !== "start") {
 				throw new Error("invalid agy process proxy command");
 			}

--- a/src/agy/process.ts
+++ b/src/agy/process.ts
@@ -1,12 +1,327 @@
 // Spawning and querying the agy CLI via Bun's native process APIs.
 
+import { Database } from "bun:sqlite";
+import { spawn as spawnChildProcess } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createInterface } from "node:readline";
+import { Readable, type Writable } from "node:stream";
+import { STATE_DIR } from "../constants";
+
 const BYPASS_MODES = new Set(["bypassPermissions", "bypass", "dontAsk"]);
+const LOCK_POLL_INTERVAL_MS = 50;
+export const AGY_PROCESS_PROXY_FLAG = "--internal-agy-process-proxy";
+const AGY_PROCESS_PROXY_READY_FD = "AGY_ACP_PROCESS_PROXY_READY_FD";
+const AGY_PROCESS_PROXY_CONTROL_FD = "AGY_ACP_PROCESS_PROXY_CONTROL_FD";
+const AGY_PROCESS_PROXY_REQUEST_FD = "AGY_ACP_PROCESS_PROXY_REQUEST_FD";
+
+interface AgyProcessProxyRequest {
+	binary: string;
+	args: string[];
+	cwd: string;
+}
+
+export interface AgySubprocess {
+	readonly stderr: ReadableStream<Uint8Array> | null;
+	readonly exited: Promise<number>;
+	readonly pid: number;
+	kill(signal?: NodeJS.Signals): void;
+}
+
+export class AgyProcessCancelledError extends Error {
+	constructor() {
+		super("agy process start cancelled");
+		this.name = "AgyProcessCancelledError";
+	}
+}
+
+function agyProcessLockFile(): string {
+	return (
+		process.env.AGY_ACP_LOCK_FILE ||
+		path.join(STATE_DIR, "agy-process-lock.sqlite")
+	);
+}
+
+function throwIfCancelled(signal?: AbortSignal): void {
+	if (signal?.aborted) throw new AgyProcessCancelledError();
+}
+
+function isSqliteBusy(error: unknown): boolean {
+	if (!error || typeof error !== "object") return false;
+	const record = error as { code?: unknown; errno?: unknown };
+	return record.code === "SQLITE_BUSY" || record.errno === 5;
+}
+
+function waitForLockRetry(signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(done, LOCK_POLL_INTERVAL_MS);
+		const onAbort = () => {
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", onAbort);
+			reject(new AgyProcessCancelledError());
+		};
+		function done() {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}
+		if (signal) {
+			signal.addEventListener("abort", onAbort, { once: true });
+			if (signal.aborted) onAbort();
+		}
+	});
+}
+
+async function acquireAgyProcessLock(
+	signal?: AbortSignal,
+): Promise<() => void> {
+	const lockFile = agyProcessLockFile();
+	fs.mkdirSync(path.dirname(lockFile), { recursive: true });
+	const database = new Database(lockFile, { create: true });
+	database.run("PRAGMA busy_timeout = 0");
+
+	try {
+		for (;;) {
+			throwIfCancelled(signal);
+			try {
+				database.run("BEGIN EXCLUSIVE");
+				break;
+			} catch (error) {
+				if (!isSqliteBusy(error)) throw error;
+				await waitForLockRetry(signal);
+			}
+		}
+
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			try {
+				database.run("ROLLBACK");
+			} catch (error) {
+				console.error(
+					`[agy-acp] failed to release agy process lock: ${(error as Error).message}`,
+				);
+			}
+			try {
+				database.close();
+			} catch (error) {
+				console.error(
+					`[agy-acp] failed to close agy process lock: ${(error as Error).message}`,
+				);
+			}
+		};
+	} catch (error) {
+		database.close();
+		throw error;
+	}
+}
+
+function encodeProxyRequest(request: AgyProcessProxyRequest): string {
+	return Buffer.from(JSON.stringify(request), "utf8").toString("base64url");
+}
+
+function parseProxyRequest(value: unknown): AgyProcessProxyRequest {
+	if (
+		!value ||
+		typeof value !== "object" ||
+		!("binary" in value) ||
+		typeof value.binary !== "string" ||
+		!("args" in value) ||
+		!Array.isArray(value.args) ||
+		!value.args.every((arg) => typeof arg === "string") ||
+		!("cwd" in value) ||
+		typeof value.cwd !== "string"
+	) {
+		throw new Error("invalid agy process proxy request");
+	}
+	return { binary: value.binary, args: value.args, cwd: value.cwd };
+}
+
+function decodeProxyRequest(encoded: string): AgyProcessProxyRequest {
+	return parseProxyRequest(
+		JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as unknown,
+	);
+}
+
+function proxyEntrypointCommand(): string[] {
+	const entrypoint = process.env.AGY_ACP_PROXY_ENTRYPOINT || Bun.main;
+	const command = [process.execPath];
+	if (path.resolve(entrypoint) !== path.resolve(process.execPath)) {
+		command.push(entrypoint);
+	}
+	command.push(AGY_PROCESS_PROXY_FLAG);
+	return command;
+}
+
+function proxyCommand(request: AgyProcessProxyRequest): string[] {
+	return [...proxyEntrypointCommand(), encodeProxyRequest(request)];
+}
+
+function readProxyRequest(encoded?: string): AgyProcessProxyRequest {
+	const descriptor = Number(process.env[AGY_PROCESS_PROXY_REQUEST_FD]);
+	if (Number.isInteger(descriptor) && descriptor >= 0) {
+		try {
+			return parseProxyRequest(
+				JSON.parse(fs.readFileSync(descriptor, "utf8")) as unknown,
+			);
+		} finally {
+			fs.closeSync(descriptor);
+		}
+	}
+	if (!encoded) throw new Error("missing agy process proxy request");
+	return decodeProxyRequest(encoded);
+}
+
+interface ProxyHandshake {
+	ready: number;
+	lines: ReturnType<typeof createInterface>;
+	iterator: AsyncIterator<string>;
+}
+
+function createProxyHandshake(): ProxyHandshake | null {
+	const ready = Number(process.env[AGY_PROCESS_PROXY_READY_FD]);
+	const control = Number(process.env[AGY_PROCESS_PROXY_CONTROL_FD]);
+	if (
+		!Number.isInteger(ready) ||
+		ready < 3 ||
+		!Number.isInteger(control) ||
+		control < 3
+	) {
+		return null;
+	}
+	const controlStream = fs.createReadStream(process.execPath, {
+		fd: control,
+		autoClose: true,
+	});
+	const lines = createInterface({ input: controlStream });
+	return { ready, lines, iterator: lines[Symbol.asyncIterator]() };
+}
+
+async function nextProxyCommand(
+	handshake: ProxyHandshake,
+): Promise<string | null> {
+	const message = await handshake.iterator.next();
+	return message.done ? null : message.value;
+}
+
+function writeProxySignal(descriptor: number, message: string): void {
+	try {
+		fs.writeSync(descriptor, `${message}\n`);
+	} catch {
+		// The bridge may have exited after authorizing the start. Keep holding the
+		// lock until agy exits even when nobody remains to receive the signal.
+	}
+	try {
+		fs.closeSync(descriptor);
+	} catch {
+		// The descriptor may already be closed after a failed write.
+	}
+}
+
+function signalProxyReady(descriptor: number): void {
+	writeProxySignal(descriptor, "ready");
+}
+
+function signalProxyError(descriptor: number, error: unknown): void {
+	const message = error instanceof Error ? error.message : String(error);
+	writeProxySignal(
+		descriptor,
+		`error:${Buffer.from(message, "utf8").toString("base64url")}`,
+	);
+}
+
+/** Internal subprocess entrypoint. The proxy owns the SQLite transaction and
+ *  outlives the ACP bridge if the bridge exits unexpectedly, so serialization
+ *  remains in force until the actual agy child exits. */
+export async function runAgyProcessProxy(encoded?: string): Promise<number> {
+	const request = readProxyRequest(encoded);
+	const controller = new AbortController();
+	const handshake = createProxyHandshake();
+	const firstCommand = handshake ? nextProxyCommand(handshake) : null;
+	if (firstCommand) {
+		void firstCommand.then(
+			(command) => {
+				if (command === null || command === "cancel") controller.abort();
+			},
+			() => controller.abort(),
+		);
+	}
+	let child: Bun.Subprocess | undefined;
+	const stop = (signal: NodeJS.Signals) => {
+		controller.abort();
+		if (!child) return;
+		if (process.platform === "win32") {
+			child.kill();
+		} else {
+			child.kill(signal);
+		}
+	};
+	const onSigint = () => stop("SIGINT");
+	const onSigterm = () => stop("SIGTERM");
+	process.once("SIGINT", onSigint);
+	if (process.platform !== "win32") process.once("SIGTERM", onSigterm);
+
+	let release: (() => void) | undefined;
+	try {
+		release = await acquireAgyProcessLock(controller.signal);
+		throwIfCancelled(controller.signal);
+		if (handshake && firstCommand) {
+			fs.writeSync(handshake.ready, "locked\n");
+			const command = await firstCommand;
+			if (command === "cancel") return 130;
+			if (command !== "start") {
+				throw new Error("invalid agy process proxy command");
+			}
+		}
+		throwIfCancelled(controller.signal);
+		try {
+			child = Bun.spawn([request.binary, ...request.args], {
+				cwd: request.cwd,
+				stdin: "ignore",
+				stdout: "inherit",
+				stderr: "inherit",
+			});
+		} catch (error) {
+			if (handshake) signalProxyError(handshake.ready, error);
+			throw error;
+		}
+		if (handshake) signalProxyReady(handshake.ready);
+		if (handshake) {
+			void nextProxyCommand(handshake).then(
+				(command) => {
+					if (command !== "cancel" || !child) return;
+					if (process.platform === "win32") {
+						child.kill();
+					} else {
+						child.kill("SIGINT");
+					}
+				},
+				() => {
+					// A closed control pipe means the bridge exited. The proxy keeps
+					// owning the lock until agy finishes.
+				},
+			);
+		}
+		return await child.exited;
+	} catch (error) {
+		if (error instanceof AgyProcessCancelledError) return 130;
+		throw error;
+	} finally {
+		release?.();
+		handshake?.lines.close();
+		process.removeListener("SIGINT", onSigint);
+		if (process.platform !== "win32") {
+			process.removeListener("SIGTERM", onSigterm);
+		}
+	}
+}
 
 /** Query agy for the list of available model ids (empty on any failure).
  *  Uses async spawn to avoid blocking the event loop (~5s for `agy models`). */
 export async function discoverModels(binary: string): Promise<string[]> {
 	try {
-		const proc = Bun.spawn([binary, "models"], {
+		const request = { binary, args: ["models"], cwd: process.cwd() };
+		const proc = Bun.spawn(proxyCommand(request), {
 			stdin: "ignore",
 			stdout: "pipe",
 			stderr: "ignore",
@@ -53,17 +368,106 @@ export function buildAgyArgs(opts: AgyArgsOptions): string[] {
 
 /** Spawn agy for a prompt. stdout is ignored (agy persists to its DB); stderr is
  *  piped so the caller can surface failures. */
-export function spawnAgy(
+export async function spawnAgy(
 	binary: string,
 	args: string[],
 	cwd: string,
-): Bun.Subprocess<"ignore", "ignore", "pipe"> {
-	return Bun.spawn([binary, ...args], {
+	signal?: AbortSignal,
+	onLockAcquired?: () => void,
+): Promise<AgySubprocess> {
+	throwIfCancelled(signal);
+	const request = { binary, args, cwd };
+	const command = proxyEntrypointCommand();
+	const child = spawnChildProcess(command[0] as string, command.slice(1), {
 		cwd,
-		stdin: "ignore",
-		stdout: "ignore",
-		stderr: "pipe",
+		env: {
+			...process.env,
+			[AGY_PROCESS_PROXY_READY_FD]: "3",
+			[AGY_PROCESS_PROXY_CONTROL_FD]: "4",
+			[AGY_PROCESS_PROXY_REQUEST_FD]: "0",
+		},
+		stdio: ["pipe", "ignore", "pipe", "pipe", "pipe"],
 	});
+	child.unref();
+	const exited = new Promise<number>((resolve, reject) => {
+		child.once("error", reject);
+		child.once("exit", (code) => resolve(code ?? 1));
+	});
+	const readyStream = child.stdio[3] as Readable | null;
+	const controlStream = child.stdio[4] as Writable | null;
+	const requestStream = child.stdin;
+	let cancelSent = false;
+	const subprocess: AgySubprocess = {
+		stderr: child.stderr
+			? (Readable.toWeb(child.stderr) as ReadableStream<Uint8Array>)
+			: null,
+		exited,
+		pid: child.pid as number,
+		kill: (killSignal) => {
+			if (cancelSent) return;
+			if (
+				controlStream &&
+				!controlStream.destroyed &&
+				!controlStream.writableEnded
+			) {
+				try {
+					controlStream.write("cancel\n");
+					cancelSent = true;
+					return;
+				} catch {
+					// Fall through to direct termination if IPC is unavailable.
+				}
+			}
+			child.kill(killSignal);
+		},
+	};
+	if (signal) {
+		const onAbort = () => {
+			if (process.platform === "win32") {
+				subprocess.kill();
+			} else {
+				subprocess.kill("SIGINT");
+			}
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		if (signal.aborted) onAbort();
+		void subprocess.exited.then(
+			() => signal.removeEventListener("abort", onAbort),
+			() => signal.removeEventListener("abort", onAbort),
+		);
+	}
+	if (!readyStream || !controlStream || !requestStream) {
+		subprocess.kill();
+		throw new Error("agy process proxy handshake pipe unavailable");
+	}
+	requestStream.end(JSON.stringify(request));
+	const lines = createInterface({ input: readyStream });
+	const iterator = lines[Symbol.asyncIterator]();
+	const waitForMessage = async (expected: string): Promise<void> => {
+		const message = await iterator.next();
+		if (!message.done && message.value.startsWith("error:")) {
+			const encodedError = message.value.slice("error:".length);
+			throw new Error(Buffer.from(encodedError, "base64url").toString("utf8"));
+		}
+		if (message.done || message.value !== expected) {
+			throw new Error(`invalid agy process proxy ${expected} signal`);
+		}
+	};
+	try {
+		await waitForMessage("locked");
+		throwIfCancelled(signal);
+		onLockAcquired?.();
+		controlStream.write("start\n");
+		await waitForMessage("ready");
+		lines.close();
+		throwIfCancelled(signal);
+	} catch (error) {
+		lines.close();
+		if (signal?.aborted) throw new AgyProcessCancelledError();
+		subprocess.kill();
+		throw error;
+	}
+	return subprocess;
 }
 
 /** Read $AGY_EXTRA_ARGS into a token list. */

--- a/tests/acp/agent.test.ts
+++ b/tests/acp/agent.test.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import { Adapter } from "../../src/acp/adapter";
 import { AgyAcpAgent } from "../../src/acp/agent";
 import { SessionManager } from "../../src/acp/sessions";
+import * as processUtils from "../../src/agy/process";
 
 const AUTH_METHOD_ID = "agy-agent";
 const _PLAN_MODE_ID = "plan";
@@ -27,6 +28,10 @@ describe("AgyAcpAgent", () => {
 		lockDir = mkdtempSync(join(tmpdir(), "agy-acp-agent-lock-"));
 		process.env.AGY_ACP_LOCK_FILE = join(lockDir, "agy.lock");
 		clientMock = { update: mock(async () => {}) };
+
+		// Stub model discovery: the real one spawns a proxy subprocess whose
+		// entrypoint is Bun.main, i.e. this test file under `bun test`.
+		spyOn(processUtils, "discoverModels").mockResolvedValue([]);
 
 		// Mock SessionManager
 		spyOn(SessionManager.prototype, "create").mockReturnValue({
@@ -133,6 +138,9 @@ describe("AgyAcpAgent", () => {
 		const discoveryExited = new Promise<number>((resolve) => {
 			finishDiscovery = resolve;
 		});
+		// This test drives discovery itself through the mocked Bun.spawn, so undo
+		// the blanket stub from beforeEach.
+		spyOn(processUtils, "discoverModels").mockRestore();
 		spyOn(Bun, "spawn").mockReturnValue({
 			stdout: "gemini-3.6-flash-high\n",
 			exited: discoveryExited,
@@ -165,6 +173,9 @@ describe("AgyAcpAgent", () => {
 		const discoveryExited = new Promise<number>((resolve) => {
 			finishDiscovery = resolve;
 		});
+		// This test drives discovery itself through the mocked Bun.spawn, so undo
+		// the blanket stub from beforeEach.
+		spyOn(processUtils, "discoverModels").mockRestore();
 		spyOn(Bun, "spawn").mockReturnValue({
 			stdout: "gemini-3.6-flash-high\n",
 			exited: discoveryExited,

--- a/tests/acp/agent.test.ts
+++ b/tests/acp/agent.test.ts
@@ -8,6 +8,9 @@ import {
 	spyOn,
 	test,
 } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Adapter } from "../../src/acp/adapter";
 import { AgyAcpAgent } from "../../src/acp/agent";
 import { SessionManager } from "../../src/acp/sessions";
@@ -18,8 +21,11 @@ const _PLAN_MODE_ID = "plan";
 describe("AgyAcpAgent", () => {
 	let agent: AgyAcpAgent;
 	let clientMock: any;
+	let lockDir: string;
 
 	beforeEach(() => {
+		lockDir = mkdtempSync(join(tmpdir(), "agy-acp-agent-lock-"));
+		process.env.AGY_ACP_LOCK_FILE = join(lockDir, "agy.lock");
 		clientMock = { update: mock(async () => {}) };
 
 		// Mock SessionManager
@@ -60,6 +66,8 @@ describe("AgyAcpAgent", () => {
 
 	afterEach(() => {
 		mock.restore();
+		delete process.env.AGY_ACP_LOCK_FILE;
+		rmSync(lockDir, { recursive: true, force: true });
 	});
 
 	test("initialize returns capabilities", async () => {
@@ -118,6 +126,73 @@ describe("AgyAcpAgent", () => {
 			clientMock,
 		);
 		expect(res.stopReason).toBe("end_turn");
+	});
+
+	test("first prompt waits for startup model discovery", async () => {
+		let finishDiscovery: (exitCode: number) => void = () => {};
+		const discoveryExited = new Promise<number>((resolve) => {
+			finishDiscovery = resolve;
+		});
+		spyOn(Bun, "spawn").mockReturnValue({
+			stdout: "gemini-3.6-flash-high\n",
+			exited: discoveryExited,
+		} as any);
+
+		const testAgent = new AgyAcpAgent({
+			binary: "agy",
+			workingDir: process.cwd(),
+			conversationsDir: "/tmp",
+			skipNarration: false,
+			version: "test",
+		});
+		const prompt = testAgent.prompt(
+			{ sessionId: "s1", prompt: [{ type: "text", text: "hello" }] } as any,
+			clientMock,
+		);
+
+		const stateBeforeDiscovery = await Promise.race([
+			prompt.then(() => "completed"),
+			Bun.sleep(10).then(() => "waiting"),
+		]);
+		expect(stateBeforeDiscovery).toBe("waiting");
+
+		finishDiscovery(0);
+		await expect(prompt).resolves.toEqual({ stopReason: "end_turn" });
+	});
+
+	test("cancellation during model discovery does not start a prompt", async () => {
+		let finishDiscovery: (exitCode: number) => void = () => {};
+		const discoveryExited = new Promise<number>((resolve) => {
+			finishDiscovery = resolve;
+		});
+		spyOn(Bun, "spawn").mockReturnValue({
+			stdout: "gemini-3.6-flash-high\n",
+			exited: discoveryExited,
+		} as any);
+		const runPromptSpy = spyOn(Adapter.prototype, "runPrompt");
+		const testAgent = new AgyAcpAgent({
+			binary: "agy",
+			workingDir: process.cwd(),
+			conversationsDir: "/tmp",
+			skipNarration: false,
+			version: "test",
+		});
+
+		const prompt = testAgent.prompt(
+			{ sessionId: "s1", prompt: [{ type: "text", text: "hello" }] } as any,
+			clientMock,
+		);
+		testAgent.cancel({ sessionId: "s1" });
+
+		const stateAfterCancel = await Promise.race([
+			prompt.then((result) => result.stopReason),
+			Bun.sleep(10).then(() => "waiting"),
+		]);
+		expect(stateAfterCancel).toBe("cancelled");
+		expect(runPromptSpy).not.toHaveBeenCalled();
+
+		finishDiscovery(0);
+		await Promise.resolve();
 	});
 
 	test("prompt formats ACP blocks into XML strings", async () => {

--- a/tests/agy/process.test.ts
+++ b/tests/agy/process.test.ts
@@ -265,6 +265,58 @@ describe("agy/process.ts", () => {
 			expect(mockSpawn).not.toHaveBeenCalled();
 		});
 
+		it("rejects when the proxy exits without a handshake signal", async () => {
+			process.env.AGY_ACP_PROXY_ENTRYPOINT = join(
+				import.meta.dir,
+				"../fixtures/silent-proxy.ts",
+			);
+			const started = performance.now();
+			await expect(
+				spawnAgy(process.execPath, ["prompt"], process.cwd()),
+			).rejects.toThrow(/locked signal/);
+			// The exit race must resolve it, not an open-ended wait on the pipe.
+			expect(performance.now() - started).toBeLessThan(2000);
+		});
+
+		it("retries when the proxy self-cancels during the handshake", async () => {
+			const markerFile = join(lockDir, "agy-launched");
+			process.env.AGY_ACP_PROXY_ENTRYPOINT = join(
+				import.meta.dir,
+				"../fixtures/flaky-proxy.ts",
+			);
+			process.env.AGY_ACP_FLAKY_PROXY_MARKER = join(lockDir, "tripped");
+			try {
+				const child = await spawnAgy(
+					process.execPath,
+					[
+						join(import.meta.dir, "../fixtures/record-agy-launch.ts"),
+						markerFile,
+					],
+					process.cwd(),
+				);
+				expect(await child.exited).toBe(0);
+				expect(existsSync(markerFile)).toBe(true);
+				expect(existsSync(process.env.AGY_ACP_FLAKY_PROXY_MARKER)).toBe(true);
+			} finally {
+				delete process.env.AGY_ACP_FLAKY_PROXY_MARKER;
+			}
+		});
+
+		it("rejects when the proxy never signals ready", async () => {
+			process.env.AGY_ACP_PROXY_ENTRYPOINT = join(
+				import.meta.dir,
+				"../fixtures/stalled-proxy.ts",
+			);
+			process.env.AGY_ACP_HANDSHAKE_TIMEOUT_MS = "200";
+			try {
+				await expect(
+					spawnAgy(process.execPath, ["prompt"], process.cwd()),
+				).rejects.toThrow("timed out waiting for agy process proxy ready");
+			} finally {
+				delete process.env.AGY_ACP_HANDSHAKE_TIMEOUT_MS;
+			}
+		});
+
 		it("continues after a separate lock-holder process dies", async () => {
 			const holder = Bun.spawn(
 				[

--- a/tests/agy/process.test.ts
+++ b/tests/agy/process.test.ts
@@ -1,15 +1,58 @@
-import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	AGY_PROCESS_PROXY_FLAG,
 	buildAgyArgs,
 	discoverModels,
 	extraArgsFromEnv,
+	runAgyProcessProxy,
 	spawnAgy,
 } from "../../src/agy/process";
 
+function encodeProxyRequest(request: {
+	binary: string;
+	args: string[];
+	cwd: string;
+}): string {
+	return Buffer.from(JSON.stringify(request), "utf8").toString("base64url");
+}
+
+function requestFromProxyCommand(command: string[]) {
+	const flagIndex = command.indexOf(AGY_PROCESS_PROXY_FLAG);
+	expect(flagIndex).toBeGreaterThan(0);
+	return JSON.parse(
+		Buffer.from(command[flagIndex + 1] as string, "base64url").toString("utf8"),
+	);
+}
+
 describe("agy/process.ts", () => {
+	let lockDir: string;
+
+	beforeEach(() => {
+		lockDir = mkdtempSync(join(tmpdir(), "agy-acp-process-lock-"));
+		process.env.AGY_ACP_LOCK_FILE = join(lockDir, "agy.lock");
+		process.env.AGY_ACP_PROXY_ENTRYPOINT = join(
+			import.meta.dir,
+			"../../index.ts",
+		);
+	});
+
 	afterEach(() => {
 		mock.restore();
 		delete process.env.AGY_EXTRA_ARGS;
+		delete process.env.AGY_ACP_LOCK_FILE;
+		delete process.env.AGY_ACP_PROXY_ENTRYPOINT;
+		rmSync(lockDir, { recursive: true, force: true });
 	});
 
 	describe("discoverModels()", () => {
@@ -20,7 +63,13 @@ describe("agy/process.ts", () => {
 			} as any);
 
 			const models = await discoverModels("dummy-binary");
-			expect(mockSpawn).toHaveBeenCalledWith(["dummy-binary", "models"], {
+			const [command, options] = mockSpawn.mock.calls[0]!;
+			expect(requestFromProxyCommand(command as string[])).toEqual({
+				binary: "dummy-binary",
+				args: ["models"],
+				cwd: process.cwd(),
+			});
+			expect(options).toEqual({
 				stdin: "ignore",
 				stdout: "pipe",
 				stderr: "ignore",
@@ -146,16 +195,307 @@ describe("agy/process.ts", () => {
 	});
 
 	describe("spawnAgy()", () => {
-		it("should spawn agy with expected config", () => {
-			const mockSpawn = spyOn(Bun, "spawn").mockReturnValue({} as any);
-			spawnAgy("my-agy", ["--foo", "bar"], "/some/cwd");
+		it("routes agy through the process proxy", async () => {
+			const markerFile = join(lockDir, "agy-launched");
+			const child = await spawnAgy(
+				process.execPath,
+				[join(import.meta.dir, "../fixtures/record-agy-launch.ts"), markerFile],
+				process.cwd(),
+				undefined,
+				() => expect(existsSync(markerFile)).toBe(false),
+			);
+			expect(await child.exited).toBe(0);
+			expect(existsSync(markerFile)).toBe(true);
+		});
 
-			expect(mockSpawn).toHaveBeenCalledWith(["my-agy", "--foo", "bar"], {
-				cwd: "/some/cwd",
-				stdin: "ignore",
-				stdout: "ignore",
-				stderr: "pipe",
+		it("surfaces proxy spawn failures through the public path", async () => {
+			const missingBinary = join(lockDir, "missing-agy");
+			await expect(
+				spawnAgy(missingBinary, ["prompt"], process.cwd()),
+			).rejects.toThrow(missingBinary);
+		});
+
+		it("serializes concurrent agy processes", async () => {
+			let finishFirst: (exitCode: number) => void = () => {};
+			const firstExited = new Promise<number>((resolve) => {
+				finishFirst = resolve;
 			});
+			let spawnCount = 0;
+			spyOn(Bun, "spawn").mockImplementation(() => {
+				spawnCount += 1;
+				return {
+					exited: spawnCount === 1 ? firstExited : Promise.resolve(0),
+				} as any;
+			});
+
+			const first = runAgyProcessProxy(
+				encodeProxyRequest({
+					binary: "my-agy",
+					args: ["first"],
+					cwd: "/some/cwd",
+				}),
+			);
+			const second = runAgyProcessProxy(
+				encodeProxyRequest({
+					binary: "my-agy",
+					args: ["second"],
+					cwd: "/some/cwd",
+				}),
+			);
+
+			const stateBeforeFirstExit = await Promise.race([
+				Promise.resolve(second).then(() => "spawned"),
+				Bun.sleep(10).then(() => "waiting"),
+			]);
+			expect(stateBeforeFirstExit).toBe("waiting");
+
+			finishFirst(0);
+			await Promise.all([first, second]);
+			expect(spawnCount).toBe(2);
+		});
+
+		it("does not spawn a proxy when start is already cancelled", async () => {
+			const mockSpawn = spyOn(Bun, "spawn");
+			const controller = new AbortController();
+			controller.abort();
+
+			await expect(
+				spawnAgy("my-agy", ["cancelled"], "/some/cwd", controller.signal),
+			).rejects.toBeInstanceOf(Error);
+			expect(mockSpawn).not.toHaveBeenCalled();
+		});
+
+		it("continues after a separate lock-holder process dies", async () => {
+			const holder = Bun.spawn(
+				[
+					process.execPath,
+					join(import.meta.dir, "../fixtures/hold-agy-process-lock.ts"),
+					process.env.AGY_ACP_LOCK_FILE as string,
+				],
+				{ stdout: "pipe", stderr: "pipe" },
+			);
+			try {
+				const reader = holder.stdout.getReader();
+				const ready = await reader.read();
+				reader.releaseLock();
+				expect(new TextDecoder().decode(ready.value)).toContain("ready");
+
+				const mockSpawn = spyOn(Bun, "spawn").mockReturnValue({
+					exited: Promise.resolve(0),
+				} as any);
+				const pending = runAgyProcessProxy(
+					encodeProxyRequest({
+						binary: "my-agy",
+						args: ["after-holder"],
+						cwd: "/some/cwd",
+					}),
+				);
+
+				const stateWhileHeld = await Promise.race([
+					pending.then(() => "spawned"),
+					Bun.sleep(10).then(() => "waiting"),
+				]);
+				expect(stateWhileHeld).toBe("waiting");
+
+				holder.kill();
+				await holder.exited;
+				await pending;
+				expect(mockSpawn).toHaveBeenCalledTimes(1);
+			} finally {
+				holder.kill();
+				await holder.exited;
+			}
+		});
+
+		it("cancels a queued proxy before it launches agy", async () => {
+			const holder = Bun.spawn(
+				[
+					process.execPath,
+					join(import.meta.dir, "../fixtures/hold-agy-process-lock.ts"),
+					process.env.AGY_ACP_LOCK_FILE as string,
+				],
+				{ stdout: "pipe", stderr: "pipe" },
+			);
+			const markerFile = join(lockDir, "agy-launched");
+			try {
+				const reader = holder.stdout.getReader();
+				await reader.read();
+				reader.releaseLock();
+
+				const controller = new AbortController();
+				const proxy = spawnAgy(
+					process.execPath,
+					[
+						join(import.meta.dir, "../fixtures/record-agy-launch.ts"),
+						markerFile,
+					],
+					process.cwd(),
+					controller.signal,
+				);
+				controller.abort();
+				await expect(proxy).rejects.toBeInstanceOf(Error);
+
+				expect(existsSync(markerFile)).toBe(false);
+			} finally {
+				holder.kill();
+				await holder.exited;
+			}
+		});
+
+		it("cancels a queued proxy when its bridge exits", async () => {
+			const holder = Bun.spawn(
+				[
+					process.execPath,
+					join(import.meta.dir, "../fixtures/hold-agy-process-lock.ts"),
+					process.env.AGY_ACP_LOCK_FILE as string,
+				],
+				{ stdout: "pipe", stderr: "pipe" },
+			);
+			const markerFile = join(lockDir, "orphan-launched");
+			let launcher: ReturnType<typeof Bun.spawn> | undefined;
+			try {
+				const holderReader = holder.stdout.getReader();
+				await holderReader.read();
+				holderReader.releaseLock();
+
+				launcher = Bun.spawn(
+					[
+						process.execPath,
+						join(import.meta.dir, "../fixtures/launch-queued-proxy.ts"),
+						process.env.AGY_ACP_LOCK_FILE as string,
+						markerFile,
+					],
+					{ stdout: "pipe", stderr: "pipe" },
+				);
+				const launcherReader = (
+					launcher.stdout as ReadableStream<Uint8Array>
+				).getReader();
+				const queued = await launcherReader.read();
+				launcherReader.releaseLock();
+				expect(new TextDecoder().decode(queued.value)).toContain("queued");
+				launcher.kill();
+				await launcher.exited;
+
+				await Bun.sleep(100);
+				holder.kill();
+				await holder.exited;
+				await Bun.sleep(300);
+				expect(existsSync(markerFile)).toBe(false);
+			} finally {
+				launcher?.kill();
+				if (launcher) await launcher.exited;
+				holder.kill();
+				await holder.exited;
+			}
+		});
+
+		it("cancels a running agy child through the proxy", async () => {
+			const startedFile = join(lockDir, "started");
+			const finishedFile = join(lockDir, "finished");
+			const proxy = await spawnAgy(
+				process.execPath,
+				[
+					join(import.meta.dir, "../fixtures/slow-agy.ts"),
+					startedFile,
+					finishedFile,
+					"500",
+				],
+				process.cwd(),
+			);
+			for (
+				let attempt = 0;
+				attempt < 100 && !existsSync(startedFile);
+				attempt++
+			) {
+				await Bun.sleep(10);
+			}
+			expect(existsSync(startedFile)).toBe(true);
+
+			proxy.kill();
+			proxy.kill();
+			expect(await proxy.exited).not.toBe(0);
+			await Bun.sleep(600);
+			expect(existsSync(finishedFile)).toBe(false);
+		});
+
+		it("keeps serialization after the bridge parent exits", async () => {
+			const firstStarted = join(lockDir, "first-started");
+			const firstFinished = join(lockDir, "first-finished");
+			const secondStarted = join(lockDir, "second-started");
+			const launcher = Bun.spawn(
+				[
+					process.execPath,
+					join(import.meta.dir, "../fixtures/launch-proxy-and-exit.ts"),
+					process.env.AGY_ACP_LOCK_FILE as string,
+					firstStarted,
+					firstFinished,
+				],
+				{ stdout: "pipe", stderr: "pipe" },
+			);
+			const proxyPid = Number(
+				(await new Response(launcher.stdout).text()).trim(),
+			);
+			await launcher.exited;
+			expect(proxyPid).toBeGreaterThan(0);
+
+			try {
+				for (
+					let attempt = 0;
+					attempt < 100 && !existsSync(firstStarted);
+					attempt++
+				) {
+					await Bun.sleep(10);
+				}
+				expect(existsSync(firstStarted)).toBe(true);
+
+				const second = await spawnAgy(
+					process.execPath,
+					[
+						join(import.meta.dir, "../fixtures/record-agy-launch.ts"),
+						secondStarted,
+					],
+					process.cwd(),
+				);
+				await second.exited;
+
+				expect(existsSync(firstFinished)).toBe(true);
+				expect(existsSync(secondStarted)).toBe(true);
+			} finally {
+				try {
+					process.kill(proxyPid, "SIGKILL");
+				} catch {
+					// The proxy normally exits before cleanup.
+				}
+			}
+		});
+
+		it("releases the lock when spawning agy throws", async () => {
+			const mockSpawn = spyOn(Bun, "spawn");
+			mockSpawn.mockImplementationOnce(() => {
+				throw new Error("spawn failed");
+			});
+			mockSpawn.mockReturnValueOnce({
+				exited: Promise.resolve(0),
+			} as any);
+
+			await expect(
+				runAgyProcessProxy(
+					encodeProxyRequest({
+						binary: "my-agy",
+						args: ["first"],
+						cwd: "/some/cwd",
+					}),
+				),
+			).rejects.toThrow("spawn failed");
+			await runAgyProcessProxy(
+				encodeProxyRequest({
+					binary: "my-agy",
+					args: ["second"],
+					cwd: "/some/cwd",
+				}),
+			);
+
+			expect(mockSpawn).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,11 +1,16 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { client, methods, ndJsonStream } from "@agentclientprotocol/sdk";
 
 describe("ACP Server E2E", () => {
 	let proc: ReturnType<typeof Bun.spawn>;
 	let connection: any;
+	let stateDir: string;
 
 	beforeAll(async () => {
+		stateDir = mkdtempSync(join(tmpdir(), "agy-acp-e2e-"));
 		proc = Bun.spawn(["bun", "run", "index.ts"], {
 			stdin: "pipe",
 			stdout: "pipe",
@@ -13,6 +18,10 @@ describe("ACP Server E2E", () => {
 			env: {
 				...process.env,
 				AGY_SKIP_DOWNLOAD: "1", // to speed it up and avoid downloading if it tries to
+				// Keep background model discovery off the real `agy` binary and off
+				// the shared default lock, so it can't outlive or slow down the suite.
+				AGY_BIN: join(stateDir, "no-such-agy"),
+				AGY_ACP_LOCK_FILE: join(stateDir, "agy-process-lock.sqlite"),
 			},
 		});
 
@@ -37,6 +46,10 @@ describe("ACP Server E2E", () => {
 		}
 		if (proc) {
 			proc.kill();
+			await proc.exited;
+		}
+		if (stateDir) {
+			rmSync(stateDir, { recursive: true, force: true });
 		}
 	});
 

--- a/tests/fixtures/flaky-proxy.ts
+++ b/tests/fixtures/flaky-proxy.ts
@@ -1,0 +1,12 @@
+// A proxy entrypoint that self-cancels the way a broken control pipe makes the
+// real proxy self-cancel — but only on its first invocation. The second run
+// delegates to the real proxy, so spawnAgy() must retry to succeed.
+import { existsSync, writeFileSync } from "node:fs";
+import { runAgyProcessProxy } from "../../src/agy/process";
+
+const marker = process.env.AGY_ACP_FLAKY_PROXY_MARKER as string;
+if (!existsSync(marker)) {
+	writeFileSync(marker, "tripped");
+	process.exit(130);
+}
+process.exit(await runAgyProcessProxy(process.argv[3]));

--- a/tests/fixtures/hold-agy-process-lock.ts
+++ b/tests/fixtures/hold-agy-process-lock.ts
@@ -1,0 +1,10 @@
+import { Database } from "bun:sqlite";
+
+const lockFile = process.argv[2];
+if (!lockFile) throw new Error("missing lock database path");
+
+const database = new Database(lockFile, { create: true });
+database.run("BEGIN EXCLUSIVE");
+console.log("ready");
+
+await new Promise(() => {});

--- a/tests/fixtures/launch-proxy-and-exit.ts
+++ b/tests/fixtures/launch-proxy-and-exit.ts
@@ -1,0 +1,22 @@
+import { writeSync } from "node:fs";
+import { join } from "node:path";
+import { spawnAgy } from "../../src/agy/process";
+
+const lockFile = process.argv[2];
+const startedFile = process.argv[3];
+const finishedFile = process.argv[4];
+if (!lockFile || !startedFile || !finishedFile) {
+	throw new Error(
+		"usage: launch-proxy-and-exit.ts <lock-file> <started-file> <finished-file>",
+	);
+}
+
+process.env.AGY_ACP_LOCK_FILE = lockFile;
+process.env.AGY_ACP_PROXY_ENTRYPOINT = join(import.meta.dir, "../../index.ts");
+const proxy = await spawnAgy(
+	process.execPath,
+	[join(import.meta.dir, "slow-agy.ts"), startedFile, finishedFile, "300"],
+	process.cwd(),
+);
+writeSync(1, `${proxy.pid}\n`);
+process.exit(0);

--- a/tests/fixtures/launch-queued-proxy.ts
+++ b/tests/fixtures/launch-queued-proxy.ts
@@ -1,0 +1,20 @@
+import { writeSync } from "node:fs";
+import { join } from "node:path";
+import { spawnAgy } from "../../src/agy/process";
+
+const lockFile = process.argv[2];
+const markerFile = process.argv[3];
+if (!lockFile || !markerFile) {
+	throw new Error("usage: launch-queued-proxy.ts <lock-file> <marker-file>");
+}
+
+process.env.AGY_ACP_LOCK_FILE = lockFile;
+process.env.AGY_ACP_PROXY_ENTRYPOINT = join(import.meta.dir, "../../index.ts");
+const pending = spawnAgy(
+	process.execPath,
+	[join(import.meta.dir, "record-agy-launch.ts"), markerFile],
+	process.cwd(),
+);
+writeSync(1, "queued\n");
+const proxy = await pending;
+await proxy.exited;

--- a/tests/fixtures/record-agy-launch.ts
+++ b/tests/fixtures/record-agy-launch.ts
@@ -1,0 +1,5 @@
+import { writeFileSync } from "node:fs";
+
+const markerFile = process.argv[2];
+if (!markerFile) throw new Error("missing marker file path");
+writeFileSync(markerFile, "launched");

--- a/tests/fixtures/silent-proxy.ts
+++ b/tests/fixtures/silent-proxy.ts
@@ -1,0 +1,3 @@
+// A proxy entrypoint that exits without ever writing a handshake signal, so
+// spawnAgy() has to notice the dead child instead of waiting on the pipe.
+process.exit(3);

--- a/tests/fixtures/slow-agy.ts
+++ b/tests/fixtures/slow-agy.ts
@@ -1,0 +1,14 @@
+import { writeFileSync } from "node:fs";
+
+const startedFile = process.argv[2];
+const finishedFile = process.argv[3];
+const delayMs = Number(process.argv[4]);
+if (!startedFile || !finishedFile || !Number.isFinite(delayMs)) {
+	throw new Error(
+		"usage: slow-agy.ts <started-file> <finished-file> <delay-ms>",
+	);
+}
+
+writeFileSync(startedFile, "started");
+await Bun.sleep(delayMs);
+writeFileSync(finishedFile, "finished");

--- a/tests/fixtures/stalled-proxy.ts
+++ b/tests/fixtures/stalled-proxy.ts
@@ -1,0 +1,8 @@
+// A proxy entrypoint that signals "locked" and then stalls without ever
+// signalling "ready", so spawnAgy() has to hit its handshake deadline.
+// It exits on its own so a missed kill can never leave it holding the
+// handshake pipes open for the rest of the suite.
+import { writeSync } from "node:fs";
+
+writeSync(3, "locked\n");
+await Bun.sleep(5000);


### PR DESCRIPTION
## Summary

- serialize every `agy` subprocess across bridge instances with an SQLite transaction
- keep lock ownership in a small self-proxy so a bridge exit cannot release the lock while its `agy` grandchild is still running
- use a two-phase lock/snapshot/start handshake so parallel first prompts bind to their own conversation databases
- propagate ACP cancellation through startup model discovery and queued process starts

## Root cause

Each bridge starts `agy models` during construction, while the first prompt can start another `agy` process. Multiple bridge processes can do the same concurrently. The `agy` CLI is not reliable under those overlapping starts.

A controlled three-client pre-fix run reproduced one non-zero exit:

```text
run 1: exit 0
run 2: exit 1, Agent execution terminated due to error
run 3: exit 0
```

Serializing only the child process was not sufficient: parallel bridges could still take the same pre-launch conversation snapshot and attach to another client's new conversation. The private proxy handshake now acquires the lock, lets the owning bridge take its snapshot, starts `agy`, and confirms that start before polling begins.

## Verification

- focused process, adapter, and agent tests: 33 passed
- regression coverage includes queued cancellation, lock-holder death, bridge-parent exit with a live grandchild, lock release after spawn failure, startup-discovery cancellation, and snapshot-before-launch ordering
- `bun run typecheck`
- `bun run lint`
- touched-file Biome check
- macOS ARM64 compiled build
- three parallel live ACP clients: all exited 0 with their own exact response markers and empty stderr
