### PR TITLE
fix(model): parse model id from first column of agy models output

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -17,7 +17,7 @@ import type {
 	SetSessionConfigOptionResponse,
 } from "@agentclientprotocol/sdk";
 import { RequestError } from "@agentclientprotocol/sdk";
-import { discoverModels } from "../agy/process";
+import { type DiscoveredModel, discoverModels } from "../agy/process";
 import {
 	AUTH_METHOD_ID,
 	AVAILABLE_COMMANDS,
@@ -55,7 +55,7 @@ export class AgyAcpAgent {
 	private readonly sessions: SessionManager;
 	private readonly adapter: Adapter;
 	private readonly replayCache = new ReplayCache();
-	private availableModels: string[] = [];
+	private availableModels: DiscoveredModel[] = [];
 	// Tracks which AcpClient is serving each session so async updates can be pushed.
 	private readonly activeClients = new Map<string, AcpClient>();
 
@@ -72,7 +72,10 @@ export class AgyAcpAgent {
 			if (fs.existsSync(MODELS_CACHE_FILE)) {
 				const cached = JSON.parse(fs.readFileSync(MODELS_CACHE_FILE, "utf-8"));
 				if (Array.isArray(cached) && cached.length > 0) {
-					this.availableModels = cached;
+					// Normalize cached items to DiscoveredModel structure for backwards compatibility with legacy string[] cache files.
+					this.availableModels = cached.map((item: any) =>
+						typeof item === "string" ? { value: item, name: item } : item,
+					);
 				}
 			}
 		} catch {
@@ -411,14 +414,14 @@ export class AgyAcpAgent {
 
 		if (models.length > 0) {
 			const currentModel =
-				session.modelId ?? models[0] ?? "Gemini 3.5 Flash (Medium)";
+				session.modelId ?? models[0]?.value ?? "gemini-3.6-flash-medium";
 			options.push({
 				id: MODEL_CONFIG_ID,
 				name: "Model",
 				category: "model",
 				type: "select",
 				currentValue: currentModel,
-				options: models.map((name) => ({ value: name, name })),
+				options: models.map((m) => ({ value: m.value, name: m.name })),
 			});
 		}
 

--- a/src/agy/process.ts
+++ b/src/agy/process.ts
@@ -2,9 +2,14 @@
 
 const BYPASS_MODES = new Set(["bypassPermissions", "bypass", "dontAsk"]);
 
-/** Query agy for the list of available model ids (empty on any failure).
+export interface DiscoveredModel {
+	value: string;
+	name: string;
+}
+
+/** Query agy for the list of available models (empty on any failure).
  *  Uses async spawn to avoid blocking the event loop (~5s for `agy models`). */
-export async function discoverModels(binary: string): Promise<string[]> {
+export async function discoverModels(binary: string): Promise<DiscoveredModel[]> {
 	try {
 		const proc = Bun.spawn([binary, "models"], {
 			stdin: "ignore",
@@ -17,7 +22,13 @@ export async function discoverModels(binary: string): Promise<string[]> {
 		return text
 			.split("\n")
 			.map((line) => line.trim())
-			.filter((line) => line.length > 0);
+			.filter((line) => line.length > 0)
+			.map((line) => {
+				const parts = line.split(/\s+/);
+				const value = parts[0] ?? "";
+				const name = parts.length > 1 ? parts.slice(1).join(" ") : value;
+				return { value, name };
+			});
 	} catch {
 		return [];
 	}

--- a/tests/agy/process.test.ts
+++ b/tests/agy/process.test.ts
@@ -25,7 +25,11 @@ describe("agy/process.ts", () => {
 				stdout: "pipe",
 				stderr: "ignore",
 			});
-			expect(models).toEqual(["model-1", "model-2", "model-3"]);
+			expect(models).toEqual([
+				{ value: "model-1", name: "model-1" },
+				{ value: "model-2", name: "model-2" },
+				{ value: "model-3", name: "model-3" },
+			]);
 		});
 
 		it("should return empty array on non-zero exit code", async () => {


### PR DESCRIPTION
## Summary
- Separates gemini-3.6-flash-high	Gemini 3.6 Flash (High)
gemini-3.6-flash-medium	Gemini 3.6 Flash (Medium)
gemini-3.6-flash-low	Gemini 3.6 Flash (Low)
gemini-3.5-flash-high	Gemini 3.5 Flash (High)
gemini-3.5-flash-medium	Gemini 3.5 Flash (Medium)
gemini-3.5-flash-low	Gemini 3.5 Flash (Low)
gemini-3.1-pro-high	Gemini 3.1 Pro (High)
gemini-3.1-pro-low	Gemini 3.1 Pro (Low)
claude-sonnet-4-6	Claude Sonnet 4.6 (Thinking)
claude-opus-4-6-thinking	Claude Opus 4.6 (Thinking)
gpt-oss-120b-medium	GPT-OSS 120B (Medium) tabular output into distinct  (model ID key) and  (display label) fields.
- Updates  config options builder to pass  structure to ACP clients.
- Updates default model fallback to `gemini-3.6-flash-medium`.
- Adds backwards-compatibility mapping and inline comment when loading legacy string-based `models.json` cache files.