### PR TITLE
feat(acp): handle /usage command non-interactively via agy -p

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -17,7 +17,7 @@ import type {
 	SetSessionConfigOptionResponse,
 } from "@agentclientprotocol/sdk";
 import { RequestError } from "@agentclientprotocol/sdk";
-import { discoverModels } from "../agy/process";
+import { discoverModels, runNonInteractivePrompt } from "../agy/process";
 import {
 	AUTH_METHOD_ID,
 	AVAILABLE_COMMANDS,
@@ -272,6 +272,23 @@ export class AgyAcpAgent {
 		}
 
 		const rawText = promptText(params.prompt);
+		const userText = rawPromptText(params.prompt).trim();
+		if (userText === "/usage" || userText.startsWith("/usage ")) {
+			const output = await runNonInteractivePrompt(
+				this.config.binary,
+				"/usage",
+				session.cwd,
+			);
+			await client.update(sessionId, {
+				sessionUpdate: "agent_message_chunk",
+				content: {
+					type: "text",
+					text: output || "No usage data available.",
+				},
+			});
+			return { stopReason: "end_turn" };
+		}
+
 		const text =
 			session.permissionMode === PLAN_MODE_ID
 				? PLAN_MODE_INJECTION + rawText
@@ -516,4 +533,18 @@ function stringField(obj: Record<string, unknown>, ...keys: string[]): string {
 		if (typeof obj[key] === "string") return obj[key] as string;
 	}
 	return "";
+}
+
+/** Extract raw user text from ACP prompt blocks without XML tag formatting. */
+function rawPromptText(prompt: unknown): string {
+	const blocks = Array.isArray(prompt) ? prompt : [];
+	const parts: string[] = [];
+	for (const block of blocks) {
+		if (!block || typeof block !== "object") continue;
+		const obj = block as Record<string, unknown>;
+		if (typeof obj.text === "string") {
+			parts.push(obj.text);
+		}
+	}
+	return parts.join("\n").trim();
 }

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -18,6 +18,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 import { RequestError } from "@agentclientprotocol/sdk";
 import { discoverModels, runNonInteractivePrompt } from "../agy/process";
+import { formatUsageOutput } from "../agy/usage-format";
 import {
 	AUTH_METHOD_ID,
 	AVAILABLE_COMMANDS,
@@ -283,7 +284,7 @@ export class AgyAcpAgent {
 				sessionUpdate: "agent_message_chunk",
 				content: {
 					type: "text",
-					text: output || "No usage data available.",
+					text: output ? formatUsageOutput(output) : "No usage data available.",
 				},
 			});
 			return { stopReason: "end_turn" };

--- a/src/agy/process.ts
+++ b/src/agy/process.ts
@@ -71,3 +71,25 @@ export function extraArgsFromEnv(): string[] {
 	const raw = process.env.AGY_EXTRA_ARGS;
 	return raw ? raw.split(/\s+/).filter((s) => s.length > 0) : [];
 }
+
+/** Execute a non-interactive agy command (print mode `-p`) and capture stdout. */
+export async function runNonInteractivePrompt(
+	binary: string,
+	prompt: string,
+	cwd?: string,
+): Promise<string> {
+	try {
+		const proc = Bun.spawn([binary, "-p", prompt], {
+			cwd,
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "ignore",
+		});
+		const text = await new Response(proc.stdout).text();
+		const exitCode = await proc.exited;
+		if (exitCode !== 0) return "";
+		return text.trim();
+	} catch {
+		return "";
+	}
+}

--- a/src/agy/usage-format.ts
+++ b/src/agy/usage-format.ts
@@ -1,0 +1,95 @@
+// Formats agy's raw `/usage` output (tab-separated rows of
+// group, metric, remaining %, reset timestamp) into a readable card layout.
+
+const BAR_WIDTH = 30;
+
+interface UsageRow {
+	group: string;
+	metric: string;
+	remaining: string;
+	resetAt: string;
+}
+
+function parseUsageRows(raw: string): UsageRow[] | null {
+	const lines = raw.split("\n").filter((line) => line.trim().length > 0);
+	if (lines.length === 0) return null;
+
+	const rows: UsageRow[] = [];
+	for (const line of lines) {
+		const cols = line.split("\t").map((col) => col.trim());
+		if (cols.length !== 4) return null;
+		const [group, metric, remaining, resetAt] = cols;
+		if (!group || !metric || !remaining || !resetAt) return null;
+		rows.push({ group, metric, remaining, resetAt });
+	}
+	return rows;
+}
+
+function formatRemainingBar(remaining: string): string {
+	const percent = Number.parseFloat(remaining);
+	if (Number.isNaN(percent)) return remaining;
+	const clamped = Math.max(0, Math.min(100, percent));
+	const filled = Math.round((clamped / 100) * BAR_WIDTH);
+	const bar = "█".repeat(filled) + "░".repeat(BAR_WIDTH - filled);
+	return `${bar} ${remaining} left`;
+}
+
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+	["day", 1000 * 60 * 60 * 24],
+	["hour", 1000 * 60 * 60],
+	["minute", 1000 * 60],
+];
+
+function formatRelativeReset(resetAt: string): string {
+	const date = new Date(resetAt);
+	if (Number.isNaN(date.getTime())) return resetAt;
+
+	const diffMs = date.getTime() - new Date().getTime();
+	const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+	for (const [unit, unitMs] of RELATIVE_UNITS) {
+		if (Math.abs(diffMs) >= unitMs) {
+			return rtf.format(Math.round(diffMs / unitMs), unit);
+		}
+	}
+	return rtf.format(Math.round(diffMs / (1000 * 60)), "minute");
+}
+
+const METRIC_LABELS: Record<string, string> = {
+	"Five Hour Limit Remaining": "Session",
+	"Weekly Limit Remaining": "Weekly",
+};
+
+function shortenMetricLabel(metric: string): string {
+	return METRIC_LABELS[metric] ?? metric;
+}
+
+/** Turn agy's raw `/usage` stdout into a grouped, human-readable card layout
+ *  with progress bars and relative reset times. Returns the raw text
+ *  unchanged if it doesn't match the expected tab-separated shape, so a
+ *  format change upstream never hides data. */
+export function formatUsageOutput(raw: string): string {
+	const trimmed = raw.trim();
+	if (!trimmed) return trimmed;
+
+	const rows = parseUsageRows(trimmed);
+	if (!rows) return trimmed;
+
+	const groups = new Map<string, UsageRow[]>();
+	for (const row of rows) {
+		const existing = groups.get(row.group);
+		if (existing) existing.push(row);
+		else groups.set(row.group, [row]);
+	}
+
+	const sections: string[] = [];
+	for (const [group, groupRows] of groups) {
+		const rowBlocks = groupRows.map(
+			(row) =>
+				`## ${shortenMetricLabel(row.metric)} (Resets ${formatRelativeReset(row.resetAt)})\n ${formatRemainingBar(row.remaining)}`,
+		);
+		sections.push(`### **${group}**\n\n${rowBlocks.join("\n\n")}`);
+	}
+
+	return sections.join("\n\n");
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -58,4 +58,5 @@ export const AVAILABLE_COMMANDS = [
 		description: "Preview a team of autonomous agents working together",
 	},
 	{ name: "learn", description: "Persist a behavior for future tasks" },
+	{ name: "usage", description: "Display raw token usage and quota metrics" },
 ];

--- a/tests/agy/usage-format.test.ts
+++ b/tests/agy/usage-format.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { formatUsageOutput } from "../../src/agy/usage-format";
+
+const HOUR = 1000 * 60 * 60;
+const DAY = HOUR * 24;
+
+describe("agy/usage-format.ts", () => {
+	describe("formatUsageOutput()", () => {
+		it("groups rows by model family with headings, bars, and relative reset times", () => {
+			const in5Hours = new Date(Date.now() + 5 * HOUR).toISOString();
+			const in7Days = new Date(Date.now() + 7 * DAY).toISOString();
+			const raw = [
+				`Gemini Models\tWeekly Limit Remaining\t98%\t${in7Days}`,
+				`Gemini Models\tFive Hour Limit Remaining\t95%\t${in5Hours}`,
+				`Claude and GPT models\tWeekly Limit Remaining\t100%\t${in7Days}`,
+				`Claude and GPT models\tFive Hour Limit Remaining\t100%\t${in5Hours}`,
+			].join("\n");
+
+			const formatted = formatUsageOutput(raw);
+
+			expect(formatted).toContain("### **Gemini Models**");
+			expect(formatted).toContain("### **Claude and GPT models**");
+			expect(formatted).toContain("## Weekly (Resets in 7 days)");
+			expect(formatted).toContain("## Session (Resets in 5 hours)");
+			expect(formatted).toContain("█".repeat(30) + " 100% left");
+			// 95% of a 30-segment bar rounds to 29 filled, 1 empty.
+			expect(formatted).toContain("█".repeat(29) + "░".repeat(1) + " 95% left");
+			// 98% of a 30-segment bar rounds to 29 filled, 1 empty (29.4 -> 29).
+			expect(formatted).toContain("█".repeat(29) + "░".repeat(1) + " 98% left");
+		});
+
+		it("falls back to the raw text when rows don't have 4 columns", () => {
+			const raw = "not\ttab\tseparated\ncorrectly";
+			expect(formatUsageOutput(raw)).toBe(raw.trim());
+		});
+
+		it("falls back to raw values for unparseable timestamps or percentages", () => {
+			const raw = "Gemini Models\tWeekly Limit Remaining\tnot-a-percent\tnot-a-date";
+			const formatted = formatUsageOutput(raw);
+			expect(formatted).toContain("## Weekly (Resets not-a-date)");
+			expect(formatted).toContain(" not-a-percent");
+		});
+
+		it("returns empty string for empty input", () => {
+			expect(formatUsageOutput("")).toBe("");
+			expect(formatUsageOutput("   \n  ")).toBe("");
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Advertises `/usage` command in `AVAILABLE_COMMANDS` via ACP `AvailableCommandsUpdate`.
- Intercepts `/usage` in `AgyAcpAgent.prompt()` before launching standard prompt turns.
- Uses reusable `runNonInteractivePrompt()` helper to query `agy -p "/usage"` cleanly and stream raw quota/usage output to the client.
- Bypasses DB session storage so `/usage` metrics are not saved as conversation history.