### PR TITLE
ci: add opt-in Homebrew tap release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,79 @@ jobs:
             dist/agy-acp-windows-x64.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-homebrew-tap:
+    name: Update Homebrew Tap
+    needs: build-and-release
+    if: vars.HOMEBREW_TAP_REPO != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.HOMEBREW_TAP_REPO }}
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          VERSION="${VERSION#v}"
+          for asset in agy-acp-darwin-arm64 agy-acp-darwin-x64 agy-acp-linux-arm64 agy-acp-linux-x64; do
+            gh release download "v${VERSION}" --repo "${GITHUB_REPOSITORY}" --pattern "$asset" --dir release-assets
+          done
+
+      - name: Generate formula
+        env:
+          VERSION: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          VERSION="${VERSION#v}"
+          mkdir -p homebrew-tap/Formula
+          cat > homebrew-tap/Formula/antigravity-acp.rb <<EOF
+          class AntigravityAcp < Formula
+            desc "Agent Client Protocol server for Google Antigravity's agy CLI"
+            homepage "https://github.com/${REPOSITORY}"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/${REPOSITORY}/releases/download/v${VERSION}/agy-acp-darwin-arm64"
+                sha256 "$(sha256sum release-assets/agy-acp-darwin-arm64 | cut -d ' ' -f 1)"
+              else
+                url "https://github.com/${REPOSITORY}/releases/download/v${VERSION}/agy-acp-darwin-x64"
+                sha256 "$(sha256sum release-assets/agy-acp-darwin-x64 | cut -d ' ' -f 1)"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm?
+                url "https://github.com/${REPOSITORY}/releases/download/v${VERSION}/agy-acp-linux-arm64"
+                sha256 "$(sha256sum release-assets/agy-acp-linux-arm64 | cut -d ' ' -f 1)"
+              else
+                url "https://github.com/${REPOSITORY}/releases/download/v${VERSION}/agy-acp-linux-x64"
+                sha256 "$(sha256sum release-assets/agy-acp-linux-x64 | cut -d ' ' -f 1)"
+              end
+            end
+
+            def install
+              bin.install Dir["*"] .first => "antigravity-acp"
+            end
+          end
+          EOF
+
+      - name: Commit and push formula
+        working-directory: homebrew-tap
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/antigravity-acp.rb
+          git diff --cached --quiet || git commit -m "Update antigravity-acp to ${VERSION#v}"
+          git push


### PR DESCRIPTION
## Summary

Adds an optional Homebrew formula update job to the release workflow. On each `v*` tag push, it:

1. Downloads the macOS and Linux release binaries from the just-published GitHub release
2. Generates a Homebrew formula (`Formula/antigravity-acp.rb`) with platform-specific URLs and SHA-256 checksums
3. Commits and pushes the formula to the configured tap repository

### Opt-in design

The job is gated behind a repository variable and only runs when configured:

- **`vars.HOMEBREW_TAP_REPO`** — Set this repository variable to e.g. `your-org/homebrew-tap` to enable. If unset, the job is skipped entirely.
- **`secrets.HOMEBREW_TAP_TOKEN`** — A GitHub token with write access to the tap repository.

No changes are needed to the existing build-and-release job — this is a purely additive, `needs: build-and-release` dependent job.

### Setup

1. Create or identify your Homebrew tap repository (e.g. `your-org/homebrew-tap`)
2. Go to Settings → Secrets and variables → Actions
3. Add variable `HOMEBREW_TAP_REPO` = `your-org/homebrew-tap`
4. Add secret `HOMEBREW_TAP_TOKEN` = a fine-grained PAT with Contents write access to the tap repo

Users can then install with:
```
brew install your-org/tap/antigravity-acp
```