### PR TITLE
fix(agy): disable print timeout with --print-timeout 0

### DIFF
--- a/src/agy/process.ts
+++ b/src/agy/process.ts
@@ -62,6 +62,7 @@ export function buildAgyArgs(opts: AgyArgsOptions): string[] {
 		// terminal for the user to approve tool calls.
 		args.push("--dangerously-skip-permissions");
 	}
+	args.push("--print-timeout", "0");
 	args.push("-p", opts.prompt);
 	return args;
 }

--- a/tests/agy/process.test.ts
+++ b/tests/agy/process.test.ts
@@ -65,6 +65,8 @@ describe("agy/process.ts", () => {
 				"--add-dir",
 				"/cwd",
 				"--dangerously-skip-permissions",
+				"--print-timeout",
+				"0",
 				"-p",
 				"hello",
 			]);
@@ -87,6 +89,8 @@ describe("agy/process.ts", () => {
 				"--add-dir",
 				"/dir2",
 				"--dangerously-skip-permissions",
+				"--print-timeout",
+				"0",
 				"-p",
 				"hello",
 			]);
@@ -107,6 +111,8 @@ describe("agy/process.ts", () => {
 				"--foo",
 				"bar",
 				"--dangerously-skip-permissions",
+				"--print-timeout",
+				"0",
 				"-p",
 				"hello",
 			]);
@@ -128,6 +134,8 @@ describe("agy/process.ts", () => {
 				"--model",
 				"model-1",
 				"--dangerously-skip-permissions",
+				"--print-timeout",
+				"0",
 				"-p",
 				"hello",
 			]);


### PR DESCRIPTION
### Summary
By default, the Google Antigravity (`agy`) CLI imposes a 5-minute timeout in print mode (`--print-timeout default 5m0s`).

For long-running turns in ACP sessions (e.g. running complex tests, deep thinking, or multi-step tool executions), `agy` would prematurely exit and abort the session after 5 minutes.

### Changes
- Added `--print-timeout 0` to `buildAgyArgs` in `src/agy/process.ts` to disable the print timeout and prevent abrupt turn cancellations.
- Updated `tests/agy/process.test.ts`.