### PR TITLE
fix(adapter): offload oversized prompts to temp file to prevent E2BIG

### DIFF
--- a/src/acp/adapter.ts
+++ b/src/acp/adapter.ts
@@ -1,8 +1,10 @@
-// Prompt-turn runtime: spawn agy, poll its DB while it runs, stream updates to
-// the client, and finalize. Bridges the agy subprocess and the conversation
-// streaming layer.
-
-import { buildAgyArgs, extraArgsFromEnv, spawnAgy } from "../agy/process";
+import * as fs from "node:fs";
+import {
+	buildAgyArgs,
+	extraArgsFromEnv,
+	preparePromptArg,
+	spawnAgy,
+} from "../agy/process";
 import { POLL_INTERVAL_MS } from "../constants";
 import { conversationSnapshot } from "../conversation/scan";
 import { StreamPoller } from "../conversation/streaming";
@@ -66,13 +68,18 @@ export class Adapter {
 				? conversationSnapshot(this.config.conversationsDir)
 				: null;
 
+		const { promptArg, tempFilePath } = preparePromptArg(
+			promptText,
+			sessionId,
+		);
+
 		const args = buildAgyArgs({
 			workingDir: effectiveCwd,
 			additionalDirs: session.additionalDirs,
 			conversationId: session.conversationId,
 			modelId: session.modelId,
 			permissionMode: session.permissionMode,
-			prompt: promptText,
+			prompt: promptArg,
 			extraArgs: extraArgsFromEnv(),
 		});
 
@@ -80,6 +87,11 @@ export class Adapter {
 		try {
 			child = spawnAgy(this.config.binary, args, effectiveCwd);
 		} catch (err) {
+			if (tempFilePath) {
+				try {
+					if (fs.existsSync(tempFilePath)) fs.unlinkSync(tempFilePath);
+				} catch {}
+			}
 			return {
 				stopReason: "end_turn",
 				conversationId: session.conversationId,
@@ -90,78 +102,86 @@ export class Adapter {
 		}
 		this.children.set(sessionId, child);
 
-		// Drain stderr concurrently (resolves when the process exits).
-		const stderrPromise = child.stderr
-			? new Response(child.stderr as ReadableStream).text()
-			: Promise.resolve("");
+		try {
+			// Drain stderr concurrently (resolves when the process exits).
+			const stderrPromise = child.stderr
+				? new Response(child.stderr as ReadableStream).text()
+				: Promise.resolve("");
 
-		const poller = new StreamPoller({
-			dir: this.config.conversationsDir,
-			conversationId: session.conversationId,
-			baseStepIdx: session.lastStepIdx,
-			skipNarration: this.config.skipNarration,
-			cwd: effectiveCwd,
-			snapshot,
-		});
+			const poller = new StreamPoller({
+				dir: this.config.conversationsDir,
+				conversationId: session.conversationId,
+				baseStepIdx: session.lastStepIdx,
+				skipNarration: this.config.skipNarration,
+				cwd: effectiveCwd,
+				snapshot,
+			});
 
-		// Serialized poll loop: emit updates in order, never overlapping.
-		const pollOnce = async () => {
-			for (const update of poller.poll()) {
-				await client.update(sessionId, update);
-			}
-		};
+			// Serialized poll loop: emit updates in order, never overlapping.
+			const pollOnce = async () => {
+				for (const update of poller.poll()) {
+					await client.update(sessionId, update);
+				}
+			};
 
-		let polling = true;
-		const loop = (async () => {
-			while (polling) {
+			let polling = true;
+			const loop = (async () => {
+				while (polling) {
+					try {
+						await pollOnce();
+					} catch (err) {
+						console.error(`[agy-acp] poll error: ${(err as Error).message}`);
+					}
+					if (!polling) break;
+					await sleep(POLL_INTERVAL_MS);
+				}
+			})();
+
+			const exitCode = await child.exited;
+			polling = false;
+			await loop;
+			this.children.delete(sessionId);
+
+			// A few trailing polls to catch rows flushed right around exit.
+			for (let attempt = 0; attempt < 3; attempt++) {
 				try {
 					await pollOnce();
 				} catch (err) {
-					console.error(`[agy-acp] poll error: ${(err as Error).message}`);
+					console.error(`[agy-acp] final poll error: ${(err as Error).message}`);
 				}
-				if (!polling) break;
-				await sleep(POLL_INTERVAL_MS);
+				if (attempt < 2) await sleep(100);
 			}
-		})();
+			poller.close();
 
-		const exitCode = await child.exited;
-		polling = false;
-		await loop;
-		this.children.delete(sessionId);
+			const stderr = (await stderrPromise).trim();
+			if (stderr.length > 0) console.error(`[agy-acp] agy stderr: ${stderr}`);
 
-		// A few trailing polls to catch rows flushed right around exit.
-		for (let attempt = 0; attempt < 3; attempt++) {
-			try {
-				await pollOnce();
-			} catch (err) {
-				console.error(`[agy-acp] final poll error: ${(err as Error).message}`);
+			const wasCancelled = this.cancelled.delete(sessionId);
+
+			const outcome: PromptOutcome = {
+				stopReason: wasCancelled ? "cancelled" : "end_turn",
+				conversationId: poller.conversationId,
+				lastStepIdx: poller.lastStepIdx,
+				hadUpdates: poller.hadUpdates,
+			};
+
+			if (!wasCancelled && exitCode !== 0) {
+				console.error(`[agy-acp] WARN: agy exited with status ${exitCode}`);
+				if (!poller.hadUpdates) {
+					outcome.error =
+						stderr.length > 0
+							? `agy failed: ${stderr}`
+							: `agy exited with status: ${exitCode}`;
+				}
 			}
-			if (attempt < 2) await sleep(100);
-		}
-		poller.close();
 
-		const stderr = (await stderrPromise).trim();
-		if (stderr.length > 0) console.error(`[agy-acp] agy stderr: ${stderr}`);
-
-		const wasCancelled = this.cancelled.delete(sessionId);
-
-		const outcome: PromptOutcome = {
-			stopReason: wasCancelled ? "cancelled" : "end_turn",
-			conversationId: poller.conversationId,
-			lastStepIdx: poller.lastStepIdx,
-			hadUpdates: poller.hadUpdates,
-		};
-
-		if (!wasCancelled && exitCode !== 0) {
-			console.error(`[agy-acp] WARN: agy exited with status ${exitCode}`);
-			if (!poller.hadUpdates) {
-				outcome.error =
-					stderr.length > 0
-						? `agy failed: ${stderr}`
-						: `agy exited with status: ${exitCode}`;
+			return outcome;
+		} finally {
+			if (tempFilePath) {
+				try {
+					if (fs.existsSync(tempFilePath)) fs.unlinkSync(tempFilePath);
+				} catch {}
 			}
 		}
-
-		return outcome;
 	}
 }

--- a/src/agy/process.ts
+++ b/src/agy/process.ts
@@ -1,6 +1,33 @@
 // Spawning and querying the agy CLI via Bun's native process APIs.
 
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
 const BYPASS_MODES = new Set(["bypassPermissions", "bypass", "dontAsk"]);
+
+// Linux MAX_ARG_STRLEN is 128KB; stay well below it to prevent E2BIG errors.
+export const MAX_PROMPT_ARG_LENGTH = 64 * 1024;
+
+/**
+ * Prepares the prompt argument for agy CLI.
+ * If the prompt is too large for a CLI argument (>64KB), offload it to a temp
+ * file to prevent E2BIG (argument list too long) spawn errors.
+ */
+export function preparePromptArg(
+	prompt: string,
+	sessionId?: string,
+): { promptArg: string; tempFilePath?: string } {
+	if (prompt.length <= MAX_PROMPT_ARG_LENGTH) {
+		return { promptArg: prompt };
+	}
+	const tempDir = os.tmpdir();
+	const filename = `agy-prompt-${sessionId ?? "turn"}-${Date.now()}.md`;
+	const tempFilePath = path.join(tempDir, filename);
+	fs.writeFileSync(tempFilePath, prompt, "utf-8");
+	const promptArg = `Please read the prompt and context in ${tempFilePath} using view_file and follow the instructions in it.`;
+	return { promptArg, tempFilePath };
+}
 
 export interface DiscoveredModel {
 	value: string;

--- a/tests/agy/process.test.ts
+++ b/tests/agy/process.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import {
+	MAX_PROMPT_ARG_LENGTH,
 	buildAgyArgs,
 	discoverModels,
 	extraArgsFromEnv,
+	preparePromptArg,
 	spawnAgy,
 } from "../../src/agy/process";
 
@@ -189,6 +191,29 @@ describe("agy/process.ts", () => {
 		it("should securely split shell variables with irregular spacing", () => {
 			process.env.AGY_EXTRA_ARGS = "  --foo   bar   --baz\t qux \n ";
 			expect(extraArgsFromEnv()).toEqual(["--foo", "bar", "--baz", "qux"]);
+		});
+	});
+
+	describe("preparePromptArg()", () => {
+		it("should keep normal prompts unchanged", () => {
+			const res = preparePromptArg("short prompt");
+			expect(res.promptArg).toBe("short prompt");
+			expect(res.tempFilePath).toBeUndefined();
+		});
+
+		it("should offload oversized prompts to a temporary file", () => {
+			const huge = "A".repeat(MAX_PROMPT_ARG_LENGTH + 100);
+			const res = preparePromptArg(huge, "test-session");
+			expect(res.tempFilePath).toBeDefined();
+			expect(res.promptArg).toContain("Please read the prompt and context in");
+			expect(res.promptArg).toContain(res.tempFilePath!);
+			
+			// Verify file content
+			const content = require("node:fs").readFileSync(res.tempFilePath!, "utf-8");
+			expect(content).toBe(huge);
+
+			// Clean up
+			require("node:fs").unlinkSync(res.tempFilePath!);
 		});
 	});
 });


### PR DESCRIPTION
### Summary
When users attach large files, diffs, or extensive context in ACP clients (such as Zed or Paseo), passing the entire prompt via the CLI argument `-p "<prompt>"` causes `Bun.spawn` / `posix_spawn` to crash with:
```text
Internal error: failed to run agy: E2BIG: argument list too long
```

### Changes
- Added `preparePromptArg` in `src/agy/process.ts` with a safe threshold (`MAX_PROMPT_ARG_LENGTH = 64KB`).
- If a prompt exceeds 64KB, it is safely offloaded to a temporary markdown file, and `agy` is instructed to read the prompt via `view_file`.
- Cleaned up the temporary file in `Adapter.runPrompt` after completion.
- Added unit tests in `tests/agy/process.test.ts`.