### PR TITLE
feat(acp): reuse agy sessions across prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 An [Agent Client Protocol](https://agentclientprotocol.com) (ACP) server for
 Google Antigravity's `agy` CLI, built on [Bun](https://bun.com). It lets any
-ACP-compatible editor drive `agy`: it spawns the CLI, streams its progress live,
-and replays conversation history on demand.
+ACP-compatible editor drive `agy`: it keeps one interactive CLI process per ACP
+session, streams its progress live, and replays conversation history on demand.
 
 ## ⚠️ Terms of Service risk
 
@@ -18,8 +18,8 @@ Google's [Antigravity Terms of Service](https://antigravity.google/terms) state:
 
 `antigravity-acp` does not itself request, store, or process any
 authentication credentials — it only spawns the official `agy` binary as a
-subprocess and talks to it over stdio; all Google OAuth login is handled
-entirely by `agy` itself, outside of this project. However, the *effect* is
+subprocess and drives it through a local pseudo-terminal; all Google OAuth
+login is handled entirely by `agy` itself, outside of this project. However, the *effect* is
 still a non-Google, ACP-compatible editor driving `agy` (and therefore your
 Antigravity account) through a third-party tool — the exact pattern Google's
 FAQ names as a Terms of Service violation (Claude Code, OpenClaw, OpenCode,
@@ -82,6 +82,20 @@ skipped when `AGY_SKIP_DOWNLOAD=1` or `$AGY_BIN` is set.
 | `AGY_SKIP_DOWNLOAD` | Set to `1` to skip the download entirely |
 | `AGY_EXTRA_ARGS` | Extra args forwarded to every `agy` invocation |
 | `AGY_CONVERSATIONS_DIR` | Custom directory where `agy` writes its conversation SQLite databases |
+| `AGY_PERSISTENT` | Persistent interactive sessions are enabled by default; set to `0` to use one process per prompt |
+| `AGY_PROMPT_TIMEOUT_MS` | Timeout for one interactive prompt turn in milliseconds (default: 300000) |
+
+### Persistent sessions
+
+By default, each ACP session owns one long-lived `agy --prompt-interactive`
+process. The first prompt pays the normal CLI startup cost; later prompts are
+submitted through the same PTY and reuse the initialized process and conversation.
+Changing the selected model, permission mode, working directory, additional
+directories, or `AGY_EXTRA_ARGS` safely restarts that session's process.
+
+Set `AGY_PERSISTENT=0` to restore the original one-shot behavior. This fallback
+is useful when a platform does not support Bun's PTY implementation or when
+debugging an `agy` TUI compatibility issue.
 
 ## Build (Single Executable Application)
 
@@ -119,12 +133,13 @@ src/
     server.ts                 Bun stdio <-> ndJsonStream <-> agent
     agent.ts                  initialize / session.* / prompt / cancel
     sessions.ts               in-memory registry + eviction
-    adapter.ts                prompt turn: spawn agy, poll, stream
+    adapter.ts                prompt turns: reuse agy PTY, poll DB, stream
     client.ts                 AgentContext wrapper (notify / request)
   agy/
     binary.ts                 resolve binary: SEA-local / bin/ / $AGY_BIN / PATH
     installer.ts              shared download + SHA-256 verify + extract logic
     process.ts                Bun.spawn, arg building, model discovery
+    interactive.ts            long-lived Bun.Terminal / PTY session runtime
   constants/
     index.ts                  shared constants (paths, poll intervals, modes, commands)
   conversation/
@@ -165,6 +180,8 @@ task/permission/error enrichment — is identical, so both drive a single
   tail of steps read and translated, then appended. (agy DBs are append-only.)
 - **Reused DB handle**: the live poll loop keeps one `bun:sqlite` handle +
   prepared statement open for the whole turn instead of reopening each tick.
+- **Reused `agy` process**: one PTY-backed interactive process is retained per
+  ACP session, eliminating repeated CLI initialization on subsequent prompts.
 - **Bun-native throughout**: `bun:sqlite`, `Bun.spawn`, `Bun.stdin`/`Bun.stdout`,
   `Bun.file`/`Bun.write` — no `better-sqlite3`, `protobufjs` runtime, or
   node-stream shims.

--- a/src/acp/adapter.ts
+++ b/src/acp/adapter.ts
@@ -1,7 +1,13 @@
-// Prompt-turn runtime: spawn agy, poll its DB while it runs, stream updates to
-// the client, and finalize. Bridges the agy subprocess and the conversation
-// streaming layer.
+// Prompt-turn runtime: drive agy, poll its DB while it runs, stream updates to
+// the client, and finalize. Interactive PTY sessions are reused across turns to
+// avoid paying agy's startup cost for every prompt; one-shot mode remains as a
+// compatibility fallback via AGY_PERSISTENT=0.
 
+import {
+	type InteractiveAgyOptions,
+	InteractiveAgyProcess,
+	persistentAgyEnabled,
+} from "../agy/interactive";
 import { buildAgyArgs, extraArgsFromEnv, spawnAgy } from "../agy/process";
 import { POLL_INTERVAL_MS } from "../constants";
 import { conversationSnapshot } from "../conversation/scan";
@@ -9,14 +15,15 @@ import { StreamPoller } from "../conversation/streaming";
 import type { Session } from "../types/session";
 import type { AcpClient } from "./client";
 
-const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+const sleep = (ms: number) =>
+	new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export interface PromptOutcome {
 	stopReason: "end_turn" | "cancelled";
 	conversationId: string | null;
 	lastStepIdx: number;
 	hadUpdates: boolean;
-	/** Set when agy failed to start, or exited non-zero with nothing streamed. */
+	/** Set when agy failed to start, or failed before anything was streamed. */
 	error?: string;
 }
 
@@ -28,44 +35,135 @@ export interface AdapterConfig {
 }
 
 export class Adapter {
-	private readonly children = new Map<string, Bun.Subprocess>();
+	private readonly oneShotChildren = new Map<string, Bun.Subprocess>();
+	private readonly interactive = new Map<string, InteractiveAgyProcess>();
 	private readonly cancelled = new Set<string>();
+	private readonly inFlight = new Set<string>();
 
 	constructor(private readonly config: AdapterConfig) {}
 
 	/** Request cancellation of an in-flight prompt for a session. */
 	cancel(sessionId: string): void {
 		this.cancelled.add(sessionId);
-		const child = this.children.get(sessionId);
-		if (child) {
-			// SIGINT allows agy to flush its DB before exiting; on Windows we fall
-			// back to an ungraceful kill because SIGINT is not a real signal there.
-			if (process.platform === "win32") {
-				child.kill();
-			} else {
-				child.kill("SIGINT");
-			}
+		this.interactive.get(sessionId)?.cancelTurn();
+
+		const child = this.oneShotChildren.get(sessionId);
+		if (!child) return;
+		// SIGINT allows agy to flush its DB before exiting; Windows has no real
+		// SIGINT for detached children, so Bun falls back to terminating it.
+		if (process.platform === "win32") {
+			child.kill();
+		} else {
+			child.kill("SIGINT");
 		}
 	}
 
-	/** Run a prompt turn end-to-end: spawn agy, stream deltas, finalize. */
+	/** Close and forget a session runtime. Persisted ACP session state is untouched. */
+	async close(sessionId: string): Promise<void> {
+		this.cancel(sessionId);
+		const runtime = this.interactive.get(sessionId);
+		this.interactive.delete(sessionId);
+		if (runtime) await runtime.close();
+		this.cancelled.delete(sessionId);
+	}
+
+	/** Run one prompt turn, reusing an interactive agy process when available. */
 	async runPrompt(
 		sessionId: string,
 		session: Session,
 		promptText: string,
 		client: AcpClient,
 	): Promise<PromptOutcome> {
+		if (this.inFlight.has(sessionId)) {
+			return this.errorOutcome(
+				session,
+				"a prompt is already running for this session",
+			);
+		}
+
+		this.inFlight.add(sessionId);
 		this.cancelled.delete(sessionId);
+		try {
+			return persistentAgyEnabled()
+				? await this.runInteractivePrompt(
+						sessionId,
+						session,
+						promptText,
+						client,
+					)
+				: await this.runOneShotPrompt(sessionId, session, promptText, client);
+		} finally {
+			this.inFlight.delete(sessionId);
+		}
+	}
 
-		// Use the session's cwd if set, otherwise fall back to the server's workingDir.
+	private async runInteractivePrompt(
+		sessionId: string,
+		session: Session,
+		promptText: string,
+		client: AcpClient,
+	): Promise<PromptOutcome> {
 		const effectiveCwd = session.cwd || this.config.workingDir;
-
-		// Snapshot existing conversations so we can bind the new DB agy creates.
 		const snapshot =
 			session.conversationId === null
 				? conversationSnapshot(this.config.conversationsDir)
 				: null;
+		const options: InteractiveAgyOptions = {
+			binary: this.config.binary,
+			workingDir: effectiveCwd,
+			additionalDirs: session.additionalDirs,
+			conversationId: session.conversationId,
+			modelId: session.modelId,
+			permissionMode: session.permissionMode,
+			extraArgs: extraArgsFromEnv(),
+		};
 
+		let runtime = this.interactive.get(sessionId);
+		if (runtime && !runtime.isCompatible(options)) {
+			await runtime.close();
+			this.interactive.delete(sessionId);
+			runtime = undefined;
+		}
+		if (!runtime) {
+			runtime = new InteractiveAgyProcess(options);
+			this.interactive.set(sessionId, runtime);
+		}
+
+		const poller = this.createPoller(session, effectiveCwd, snapshot);
+		try {
+			await this.streamUntil(
+				sessionId,
+				client,
+				poller,
+				runtime.runTurn(promptText),
+			);
+		} catch (error) {
+			await runtime.close();
+			this.interactive.delete(sessionId);
+			const wasCancelled = this.cancelled.delete(sessionId);
+			const outcome = this.pollerOutcome(session, poller, wasCancelled);
+			if (!wasCancelled && !poller.hadUpdates) {
+				outcome.error = `agy failed: ${(error as Error).message}`;
+			}
+			return outcome;
+		}
+
+		const wasCancelled = this.cancelled.delete(sessionId);
+		runtime.bindConversation(poller.conversationId);
+		return this.pollerOutcome(session, poller, wasCancelled);
+	}
+
+	private async runOneShotPrompt(
+		sessionId: string,
+		session: Session,
+		promptText: string,
+		client: AcpClient,
+	): Promise<PromptOutcome> {
+		const effectiveCwd = session.cwd || this.config.workingDir;
+		const snapshot =
+			session.conversationId === null
+				? conversationSnapshot(this.config.conversationsDir)
+				: null;
 		const args = buildAgyArgs({
 			workingDir: effectiveCwd,
 			additionalDirs: session.additionalDirs,
@@ -79,23 +177,48 @@ export class Adapter {
 		let child: Bun.Subprocess;
 		try {
 			child = spawnAgy(this.config.binary, args, effectiveCwd);
-		} catch (err) {
-			return {
-				stopReason: "end_turn",
-				conversationId: session.conversationId,
-				lastStepIdx: session.lastStepIdx,
-				hadUpdates: false,
-				error: `failed to run agy: ${(err as Error).message}`,
-			};
+		} catch (error) {
+			return this.errorOutcome(
+				session,
+				`failed to run agy: ${(error as Error).message}`,
+			);
 		}
-		this.children.set(sessionId, child);
+		this.oneShotChildren.set(sessionId, child);
 
-		// Drain stderr concurrently (resolves when the process exits).
 		const stderrPromise = child.stderr
 			? new Response(child.stderr as ReadableStream).text()
 			: Promise.resolve("");
+		const poller = this.createPoller(session, effectiveCwd, snapshot);
+		const exitCode = await this.streamUntil(
+			sessionId,
+			client,
+			poller,
+			child.exited,
+		);
+		this.oneShotChildren.delete(sessionId);
 
-		const poller = new StreamPoller({
+		const stderr = (await stderrPromise).trim();
+		if (stderr.length > 0) console.error(`[agy-acp] agy stderr: ${stderr}`);
+		const wasCancelled = this.cancelled.delete(sessionId);
+		const outcome = this.pollerOutcome(session, poller, wasCancelled);
+		if (!wasCancelled && exitCode !== 0) {
+			console.error(`[agy-acp] WARN: agy exited with status ${exitCode}`);
+			if (!poller.hadUpdates) {
+				outcome.error =
+					stderr.length > 0
+						? `agy failed: ${stderr}`
+						: `agy exited with status: ${exitCode}`;
+			}
+		}
+		return outcome;
+	}
+
+	private createPoller(
+		session: Session,
+		effectiveCwd: string,
+		snapshot: Set<string> | null,
+	): StreamPoller {
+		return new StreamPoller({
 			dir: this.config.conversationsDir,
 			conversationId: session.conversationId,
 			baseStepIdx: session.lastStepIdx,
@@ -103,8 +226,15 @@ export class Adapter {
 			cwd: effectiveCwd,
 			snapshot,
 		});
+	}
 
-		// Serialized poll loop: emit updates in order, never overlapping.
+	/** Poll serially until the supplied process/turn promise settles. */
+	private async streamUntil<T>(
+		sessionId: string,
+		client: AcpClient,
+		poller: StreamPoller,
+		completion: Promise<T>,
+	): Promise<T> {
 		const pollOnce = async () => {
 			for (const update of poller.poll()) {
 				await client.update(sessionId, update);
@@ -116,52 +246,61 @@ export class Adapter {
 			while (polling) {
 				try {
 					await pollOnce();
-				} catch (err) {
-					console.error(`[agy-acp] poll error: ${(err as Error).message}`);
+				} catch (error) {
+					console.error(`[agy-acp] poll error: ${(error as Error).message}`);
 				}
 				if (!polling) break;
 				await sleep(POLL_INTERVAL_MS);
 			}
 		})();
 
-		const exitCode = await child.exited;
+		let result: T | undefined;
+		let failure: unknown;
+		try {
+			result = await completion;
+		} catch (error) {
+			failure = error;
+		}
 		polling = false;
 		await loop;
-		this.children.delete(sessionId);
 
-		// A few trailing polls to catch rows flushed right around exit.
+		// Catch rows flushed immediately after the TUI returns to idle/process exits.
 		for (let attempt = 0; attempt < 3; attempt++) {
 			try {
 				await pollOnce();
-			} catch (err) {
-				console.error(`[agy-acp] final poll error: ${(err as Error).message}`);
+			} catch (error) {
+				console.error(
+					`[agy-acp] final poll error: ${(error as Error).message}`,
+				);
 			}
 			if (attempt < 2) await sleep(100);
 		}
 		poller.close();
 
-		const stderr = (await stderrPromise).trim();
-		if (stderr.length > 0) console.error(`[agy-acp] agy stderr: ${stderr}`);
+		if (failure) throw failure;
+		return result as T;
+	}
 
-		const wasCancelled = this.cancelled.delete(sessionId);
-
-		const outcome: PromptOutcome = {
+	private pollerOutcome(
+		session: Session,
+		poller: StreamPoller,
+		wasCancelled: boolean,
+	): PromptOutcome {
+		return {
 			stopReason: wasCancelled ? "cancelled" : "end_turn",
-			conversationId: poller.conversationId,
+			conversationId: poller.conversationId ?? session.conversationId,
 			lastStepIdx: poller.lastStepIdx,
 			hadUpdates: poller.hadUpdates,
 		};
+	}
 
-		if (!wasCancelled && exitCode !== 0) {
-			console.error(`[agy-acp] WARN: agy exited with status ${exitCode}`);
-			if (!poller.hadUpdates) {
-				outcome.error =
-					stderr.length > 0
-						? `agy failed: ${stderr}`
-						: `agy exited with status: ${exitCode}`;
-			}
-		}
-
-		return outcome;
+	private errorOutcome(session: Session, error: string): PromptOutcome {
+		return {
+			stopReason: "end_turn",
+			conversationId: session.conversationId,
+			lastStepIdx: session.lastStepIdx,
+			hadUpdates: false,
+			error,
+		};
 	}
 }

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -272,6 +272,7 @@ export class AgyAcpAgent {
 		sessionId?: string;
 	}): Promise<DeleteSessionResponse> {
 		const sessionId = this.requireSessionId(params.sessionId);
+		await this.adapter.close(sessionId);
 		const deleted = await this.sessions.delete(sessionId);
 		if (!deleted) throw RequestError.resourceNotFound(sessionId);
 		this.activeClients.delete(sessionId);
@@ -282,7 +283,11 @@ export class AgyAcpAgent {
 	closeSession(params: { sessionId?: string }): CloseSessionResponse {
 		const sessionId = params.sessionId;
 		if (sessionId) {
-			this.adapter.cancel(sessionId);
+			void this.adapter.close(sessionId).catch((error) => {
+				console.error(
+					`[agy-acp] failed to close session ${sessionId}: ${(error as Error).message}`,
+				);
+			});
 			this.sessions.evict(sessionId);
 			this.activeClients.delete(sessionId);
 		}

--- a/src/agy/installer.ts
+++ b/src/agy/installer.ts
@@ -56,7 +56,7 @@ export const RELEASES: Record<string, Release> = {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 export function releaseUrl(asset: string): string {
-	return `https://github.com/${GITHUB_REPO}/releases/download/v${AGY_VERSION}/${asset}`;
+	return `https://github.com/${GITHUB_REPO}/releases/download/${AGY_VERSION}/${asset}`;
 }
 
 export function sha256hex(buf: Buffer): string {

--- a/src/agy/interactive.ts
+++ b/src/agy/interactive.ts
@@ -1,0 +1,377 @@
+// Long-lived agy interactive runtime backed by Bun's cross-platform PTY.
+// The terminal output is used only to detect busy/idle lifecycle transitions;
+// user-visible content continues to come from the conversation database.
+
+import { buildInteractiveAgyArgs } from "./process";
+
+const BUSY_MARKER = "esc to cancel";
+const IDLE_MARKER = "? for shortcuts";
+const TRUST_MARKER = "Do you trust the contents of this project?";
+const DEFAULT_PROMPT_TIMEOUT_MS = 5 * 60 * 1000;
+const IDLE_SETTLE_MS = 250;
+const TERMINAL_TAIL_LIMIT = 4096;
+const SCAN_OVERLAP = 256;
+const BRACKETED_PASTE_START = "\u001b[200~";
+const BRACKETED_PASTE_END = "\u001b[201~";
+const ESCAPE = String.fromCharCode(27);
+const BELL = String.fromCharCode(7);
+const ANSI_OSC_PATTERN = new RegExp(
+	`${ESCAPE}\\][^${BELL}]*(?:${BELL}|${ESCAPE}\\\\)`,
+	"g",
+);
+const ANSI_CSI_PATTERN = new RegExp(`${ESCAPE}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+const sleep = (ms: number) =>
+	new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+type TerminalState = "unknown" | "busy" | "idle";
+
+export interface TerminalCheckpoint {
+	busyGeneration: number;
+	idleGeneration: number;
+	trustGeneration: number;
+}
+
+/**
+ * Tracks lifecycle markers emitted by the agy TUI without attempting to emulate
+ * the whole terminal screen. Absolute marker offsets prevent overlap rescans
+ * from replaying an older state transition.
+ */
+export class TerminalStateTracker {
+	private state: TerminalState = "unknown";
+	private busyGeneration = 0;
+	private idleGeneration = 0;
+	private trustGeneration = 0;
+	private totalChars = 0;
+	private lastMarkerOffset = -1;
+	private lastStateChangeAt = 0;
+	private scanOverlap = "";
+	private tail = "";
+
+	feed(text: string, now = Date.now()): void {
+		const clean = stripTerminalControl(text);
+		if (!clean) return;
+
+		const combined = this.scanOverlap + clean;
+		const combinedStart = this.totalChars - this.scanOverlap.length;
+		const marker =
+			/esc to cancel|\? for shortcuts|Do you trust the contents of this project\?/g;
+		for (const match of combined.matchAll(marker)) {
+			const relative = match.index ?? -1;
+			if (relative < 0) continue;
+			const absolute = combinedStart + relative;
+			if (absolute <= this.lastMarkerOffset) continue;
+			this.lastMarkerOffset = absolute;
+
+			switch (match[0]) {
+				case BUSY_MARKER:
+					if (this.state !== "busy") {
+						this.state = "busy";
+						this.busyGeneration++;
+						this.lastStateChangeAt = now;
+					}
+					break;
+				case IDLE_MARKER:
+					if (this.state !== "idle") {
+						this.state = "idle";
+						this.idleGeneration++;
+						this.lastStateChangeAt = now;
+					}
+					break;
+				case TRUST_MARKER:
+					this.trustGeneration++;
+					break;
+			}
+		}
+
+		this.totalChars += clean.length;
+		this.scanOverlap = combined.slice(-SCAN_OVERLAP);
+		this.tail = (this.tail + clean).slice(-TERMINAL_TAIL_LIMIT);
+	}
+
+	checkpoint(): TerminalCheckpoint {
+		return {
+			busyGeneration: this.busyGeneration,
+			idleGeneration: this.idleGeneration,
+			trustGeneration: this.trustGeneration,
+		};
+	}
+
+	turnCompleted(checkpoint: TerminalCheckpoint, now = Date.now()): boolean {
+		return (
+			this.busyGeneration > checkpoint.busyGeneration &&
+			this.idleGeneration > checkpoint.idleGeneration &&
+			this.state === "idle" &&
+			now - this.lastStateChangeAt >= IDLE_SETTLE_MS
+		);
+	}
+
+	trustPromptedAfter(checkpoint: TerminalCheckpoint): boolean {
+		return this.trustGeneration > checkpoint.trustGeneration;
+	}
+
+	diagnosticTail(): string {
+		return this.tail.trim();
+	}
+}
+
+export interface InteractiveAgyOptions {
+	binary: string;
+	workingDir: string;
+	additionalDirs: string[];
+	conversationId: string | null;
+	modelId: string | null;
+	permissionMode: string | null;
+	extraArgs: string[];
+	promptTimeoutMs?: number;
+}
+
+/** One long-lived agy TUI process bound to one ACP session/conversation. */
+export class InteractiveAgyProcess {
+	private readonly tracker = new TerminalStateTracker();
+	private readonly decoder = new TextDecoder();
+	private terminal: Bun.Terminal | null = null;
+	private child: Bun.Subprocess | null = null;
+	private activeTurn = false;
+	private closing = false;
+	private boundConversationId: string | null;
+
+	constructor(private readonly options: InteractiveAgyOptions) {
+		this.boundConversationId = options.conversationId;
+	}
+
+	get conversationId(): string | null {
+		return this.boundConversationId;
+	}
+
+	get alive(): boolean {
+		return this.child !== null && this.child.exitCode === null && !this.closing;
+	}
+
+	bindConversation(conversationId: string | null): void {
+		if (conversationId) this.boundConversationId = conversationId;
+	}
+
+	isCompatible(options: InteractiveAgyOptions): boolean {
+		return (
+			this.alive &&
+			this.options.binary === options.binary &&
+			this.options.workingDir === options.workingDir &&
+			this.options.modelId === options.modelId &&
+			this.options.permissionMode === options.permissionMode &&
+			this.boundConversationId === options.conversationId &&
+			arrayEquals(this.options.additionalDirs, options.additionalDirs) &&
+			arrayEquals(this.options.extraArgs, options.extraArgs)
+		);
+	}
+
+	/** Start the TUI with the first prompt, or paste a later prompt into it. */
+	async runTurn(prompt: string): Promise<void> {
+		if (this.activeTurn)
+			throw new Error("agy interactive session already has an active turn");
+		if (this.closing) throw new Error("agy interactive session is closing");
+
+		this.activeTurn = true;
+		const checkpoint = this.tracker.checkpoint();
+		try {
+			if (this.child === null) {
+				this.start(prompt);
+			} else {
+				await this.submitPrompt(prompt);
+			}
+			await this.waitForTurn(checkpoint);
+		} finally {
+			this.activeTurn = false;
+		}
+	}
+
+	/** Ask the TUI to cancel the current generation. */
+	cancelTurn(): void {
+		if (!this.activeTurn || !this.terminal || this.terminal.closed) return;
+		this.terminal.write("\u001b");
+
+		// If the TUI does not return to idle, terminate it so ACP cancellation
+		// cannot leave a permanently wedged session runtime.
+		setTimeout(() => {
+			if (this.activeTurn) this.forceStop();
+		}, 2_000);
+	}
+
+	async close(): Promise<void> {
+		if (this.closing) return;
+		this.closing = true;
+
+		const child = this.child;
+		const terminal = this.terminal;
+		if (child && child.exitCode === null && terminal && !terminal.closed) {
+			terminal.write("\u0003");
+			await sleep(75);
+			terminal.write("\u0003");
+			await Promise.race([child.exited.then(() => undefined), sleep(300)]);
+		}
+		if (child?.exitCode === null) child.kill();
+		if (terminal && !terminal.closed) terminal.close();
+
+		this.child = null;
+		this.terminal = null;
+	}
+
+	private start(prompt: string): void {
+		const terminal = new Bun.Terminal({
+			cols: 120,
+			rows: 40,
+			data: (_terminal, data) => {
+				const text = this.decoder.decode(data, { stream: true });
+				this.tracker.feed(text);
+			},
+		});
+
+		const args = buildInteractiveAgyArgs({
+			workingDir: this.options.workingDir,
+			additionalDirs: this.options.additionalDirs,
+			conversationId: this.options.conversationId,
+			modelId: this.options.modelId,
+			permissionMode: this.options.permissionMode,
+			prompt,
+			extraArgs: this.options.extraArgs,
+		});
+
+		try {
+			this.child = Bun.spawn([this.options.binary, ...args], {
+				cwd: this.options.workingDir,
+				terminal,
+			});
+			this.terminal = terminal;
+		} catch (error) {
+			terminal.close();
+			throw error;
+		}
+	}
+
+	private async submitPrompt(prompt: string): Promise<void> {
+		const terminal = this.terminal;
+		if (!terminal || terminal.closed || !this.alive) {
+			throw new Error("agy interactive process is not available");
+		}
+
+		// Bracketed paste keeps embedded context/newlines inside the editor instead
+		// of treating every newline as a separate submitted prompt.
+		const safePrompt = sanitizePromptForTerminal(prompt);
+		await writeAll(
+			terminal,
+			`${BRACKETED_PASTE_START}${safePrompt}${BRACKETED_PASTE_END}`,
+		);
+		await sleep(20);
+		await writeAll(terminal, "\r");
+	}
+
+	private async waitForTurn(checkpoint: TerminalCheckpoint): Promise<void> {
+		const timeoutMs = this.options.promptTimeoutMs ?? promptTimeoutMsFromEnv();
+		const deadline = Date.now() + timeoutMs;
+
+		while (Date.now() < deadline) {
+			if (this.tracker.trustPromptedAfter(checkpoint)) {
+				throw new Error(
+					`agy requires workspace trust for ${this.options.workingDir}; run agy in that directory once and approve it`,
+				);
+			}
+			if (this.tracker.turnCompleted(checkpoint)) return;
+
+			const exitCode = this.child?.exitCode;
+			if (exitCode !== null && exitCode !== undefined) {
+				const detail = this.tracker.diagnosticTail();
+				throw new Error(
+					detail
+						? `agy interactive process exited with status ${exitCode}: ${detail}`
+						: `agy interactive process exited with status ${exitCode}`,
+				);
+			}
+			await sleep(25);
+		}
+
+		const detail = this.tracker.diagnosticTail();
+		throw new Error(
+			detail
+				? `agy interactive prompt timed out after ${timeoutMs}ms: ${detail}`
+				: `agy interactive prompt timed out after ${timeoutMs}ms`,
+		);
+	}
+
+	private forceStop(): void {
+		if (this.child?.exitCode === null) this.child.kill();
+		if (this.terminal && !this.terminal.closed) this.terminal.close();
+	}
+}
+
+export function persistentAgyEnabled(): boolean {
+	return (
+		process.env.AGY_PERSISTENT !== "0" && typeof Bun.Terminal === "function"
+	);
+}
+
+export function promptTimeoutMsFromEnv(): number {
+	const raw = process.env.AGY_PROMPT_TIMEOUT_MS;
+	if (!raw) return DEFAULT_PROMPT_TIMEOUT_MS;
+	const parsed = Number(raw);
+	return Number.isFinite(parsed) && parsed > 0
+		? Math.floor(parsed)
+		: DEFAULT_PROMPT_TIMEOUT_MS;
+}
+
+function arrayEquals(
+	left: readonly string[],
+	right: readonly string[],
+): boolean {
+	return (
+		left.length === right.length &&
+		left.every((value, index) => value === right[index])
+	);
+}
+
+function sanitizePromptForTerminal(prompt: string): string {
+	return filterCharacters(
+		prompt.replace(/\r\n/g, "\n").replace(/\r/g, "\n"),
+		(code) => code !== 0 && code !== 27,
+	);
+}
+
+async function writeAll(terminal: Bun.Terminal, input: string): Promise<void> {
+	const bytes = new TextEncoder().encode(input);
+	let offset = 0;
+	while (offset < bytes.length) {
+		const written = terminal.write(bytes.subarray(offset));
+		if (written > 0) {
+			offset += written;
+		} else {
+			await sleep(5);
+		}
+	}
+}
+
+function stripTerminalControl(input: string): string {
+	const withoutAnsi = input
+		.replace(ANSI_OSC_PATTERN, "")
+		.replace(ANSI_CSI_PATTERN, "");
+	return filterCharacters(
+		withoutAnsi,
+		(code) =>
+			!(
+				(code >= 0 && code <= 8) ||
+				code === 11 ||
+				code === 12 ||
+				(code >= 14 && code <= 31) ||
+				code === 127
+			),
+	);
+}
+
+function filterCharacters(
+	input: string,
+	keep: (code: number) => boolean,
+): string {
+	let output = "";
+	for (const char of input) {
+		if (keep(char.charCodeAt(0))) output += char;
+	}
+	return output;
+}

--- a/src/agy/process.ts
+++ b/src/agy/process.ts
@@ -46,8 +46,7 @@ export interface AgyArgsOptions {
 	extraArgs?: string[];
 }
 
-/** Build the agy CLI argument vector for a single prompt turn. */
-export function buildAgyArgs(opts: AgyArgsOptions): string[] {
+function buildCommonAgyArgs(opts: AgyArgsOptions): string[] {
 	const args = ["--add-dir", opts.workingDir];
 	for (const dir of opts.additionalDirs ?? []) {
 		args.push("--add-dir", dir);
@@ -62,7 +61,21 @@ export function buildAgyArgs(opts: AgyArgsOptions): string[] {
 		// terminal for the user to approve tool calls.
 		args.push("--dangerously-skip-permissions");
 	}
+	return args;
+}
+
+/** Build the agy CLI argument vector for a single, non-interactive prompt turn. */
+export function buildAgyArgs(opts: AgyArgsOptions): string[] {
+	const args = buildCommonAgyArgs(opts);
 	args.push("-p", opts.prompt);
+	return args;
+}
+
+/** Build the agy CLI argument vector for a long-lived interactive session.
+ *  The first prompt is supplied on startup; later prompts are sent through the PTY. */
+export function buildInteractiveAgyArgs(opts: AgyArgsOptions): string[] {
+	const args = buildCommonAgyArgs(opts);
+	args.push("--prompt-interactive", opts.prompt);
 	return args;
 }
 

--- a/src/conversation/database.ts
+++ b/src/conversation/database.ts
@@ -86,8 +86,9 @@ export class ConversationDb {
 		const dbPath = conversationDbPath(dir, id);
 		if (!fs.existsSync(dbPath)) return null;
 
+		let db: Database | null = null;
 		try {
-			const db = new Database(dbPath, { readonly: true });
+			db = new Database(dbPath, { readonly: true });
 			const hasSteps = db
 				.query(
 					"SELECT COUNT(*) > 0 AS present FROM sqlite_master WHERE type='table' AND name='steps'",
@@ -102,6 +103,7 @@ export class ConversationDb {
 			}
 			return new ConversationDb(db, db.query(SELECT_ROWS));
 		} catch {
+			db?.close();
 			return null;
 		}
 	}

--- a/src/updates/utils.ts
+++ b/src/updates/utils.ts
@@ -150,7 +150,7 @@ export function toDisplayPath(filePath: string, cwd?: string): string {
 		resolvedFile.startsWith(resolvedCwd + path.sep) ||
 		resolvedFile === resolvedCwd
 	) {
-		return path.relative(resolvedCwd, resolvedFile);
+		return path.relative(resolvedCwd, resolvedFile).split(path.sep).join("/");
 	}
 	return filePath;
 }

--- a/tests/agy/installer.test.ts
+++ b/tests/agy/installer.test.ts
@@ -50,7 +50,7 @@ describe("agy/installer.ts", () => {
 	describe("releaseUrl()", () => {
 		it("should format the URL correctly", () => {
 			expect(releaseUrl("my-asset.zip")).toBe(
-				`https://github.com/${GITHUB_REPO}/releases/download/v${AGY_VERSION}/my-asset.zip`,
+				`https://github.com/${GITHUB_REPO}/releases/download/${AGY_VERSION}/my-asset.zip`,
 			);
 		});
 	});

--- a/tests/agy/interactive.test.ts
+++ b/tests/agy/interactive.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	persistentAgyEnabled,
+	promptTimeoutMsFromEnv,
+	TerminalStateTracker,
+} from "../../src/agy/interactive";
+
+describe("TerminalStateTracker", () => {
+	test("recognizes a busy-to-idle turn across split PTY chunks", () => {
+		const tracker = new TerminalStateTracker();
+		const checkpoint = tracker.checkpoint();
+
+		tracker.feed("esc to can", 1_000);
+		tracker.feed("cel", 1_010);
+		expect(tracker.turnCompleted(checkpoint, 1_020)).toBe(false);
+
+		tracker.feed("\u001b[2K? for short", 1_100);
+		tracker.feed("cuts", 1_110);
+		expect(tracker.turnCompleted(checkpoint, 1_200)).toBe(false);
+		expect(tracker.turnCompleted(checkpoint, 1_360)).toBe(true);
+	});
+
+	test("does not replay lifecycle markers from overlap scans", () => {
+		const tracker = new TerminalStateTracker();
+		tracker.feed("esc to cancel", 1_000);
+		tracker.feed("? for shortcuts", 1_400);
+		const checkpoint = tracker.checkpoint();
+
+		tracker.feed("terminal repaint without state markers", 2_000);
+		expect(tracker.turnCompleted(checkpoint, 3_000)).toBe(false);
+	});
+
+	test("detects a workspace trust prompt", () => {
+		const tracker = new TerminalStateTracker();
+		const checkpoint = tracker.checkpoint();
+
+		tracker.feed("Do you trust the contents of this project?", 1_000);
+		expect(tracker.trustPromptedAfter(checkpoint)).toBe(true);
+	});
+});
+
+describe("persistent agy settings", () => {
+	afterEach(() => {
+		delete process.env.AGY_PERSISTENT;
+		delete process.env.AGY_PROMPT_TIMEOUT_MS;
+	});
+
+	test("is enabled by default and can be explicitly disabled", () => {
+		expect(persistentAgyEnabled()).toBe(true);
+		process.env.AGY_PERSISTENT = "0";
+		expect(persistentAgyEnabled()).toBe(false);
+	});
+
+	test("uses a positive timeout override and ignores invalid values", () => {
+		process.env.AGY_PROMPT_TIMEOUT_MS = "1234";
+		expect(promptTimeoutMsFromEnv()).toBe(1234);
+
+		process.env.AGY_PROMPT_TIMEOUT_MS = "invalid";
+		expect(promptTimeoutMsFromEnv()).toBe(5 * 60 * 1000);
+	});
+});

--- a/tests/agy/process.test.ts
+++ b/tests/agy/process.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import {
 	buildAgyArgs,
+	buildInteractiveAgyArgs,
 	discoverModels,
 	extraArgsFromEnv,
 	spawnAgy,
@@ -164,6 +165,36 @@ describe("agy/process.ts", () => {
 				prompt: "hello",
 			});
 			expect(argsNullMode).toContain("--dangerously-skip-permissions");
+		});
+	});
+
+	describe("buildInteractiveAgyArgs()", () => {
+		it("should preserve common session options and use prompt-interactive", () => {
+			const args = buildInteractiveAgyArgs({
+				workingDir: "/cwd",
+				additionalDirs: ["/extra"],
+				conversationId: "conv-1",
+				modelId: "model-1",
+				permissionMode: "bypassPermissions",
+				prompt: "hello",
+				extraArgs: ["--effort", "low"],
+			});
+
+			expect(args).toEqual([
+				"--add-dir",
+				"/cwd",
+				"--add-dir",
+				"/extra",
+				"--effort",
+				"low",
+				"--conversation",
+				"conv-1",
+				"--model",
+				"model-1",
+				"--dangerously-skip-permissions",
+				"--prompt-interactive",
+				"hello",
+			]);
 		});
 	});
 


### PR DESCRIPTION
## Summary

This change keeps one PTY-backed `agy --prompt-interactive` process alive per ACP session instead of starting a fresh CLI process for every prompt.

- Reuse the initialized `agy` process and conversation state for subsequent prompts.
- Continue streaming progress from the conversation database while prompts are submitted through the PTY.
- Restart the persistent process when session-critical settings change, including model, permission mode, working directory, additional directories, or `AGY_EXTRA_ARGS`.
- Close persistent processes when ACP sessions are closed or deleted.
- Add `AGY_PERSISTENT=0` as a compatibility fallback to the existing one-shot behavior.
- Add `AGY_PROMPT_TIMEOUT_MS` to bound an interactive prompt turn.
- Document the persistent-session behavior and add focused tests for PTY state tracking, settings, and argument construction.

## Motivation

Starting `agy` for every prompt repeatedly pays CLI initialization cost. Reusing one interactive process per ACP session makes follow-up turns substantially cheaper while preserving the existing ACP streaming and replay model.

## Validation

- `bun run typecheck` ✅
- `bun test` ✅ — 202 tests passed
- `bunx biome check .` ⚠️ — the current upstream `main` already reports the same 5 formatting errors / diagnostics; this branch introduces no additional Biome diagnostic headers compared with a clean `upstream/main` worktree.

The one-shot execution path remains available via `AGY_PERSISTENT=0` for compatibility and debugging.
