### PR TITLE
fix: close tool-call lifecycle with tool_call_update when steps finish mid-run

### DIFF
--- a/src/conversation/translator.ts
+++ b/src/conversation/translator.ts
@@ -40,6 +40,11 @@ export class Translator {
 	private readonly agentTextLengths = new Map<number, number>();
 	// Streaming: tool step indices already emitted (dedup across polls).
 	private readonly emittedSteps = new Set<number>();
+	// Streaming: tool steps emitted with a non-terminal status (idx -> toolCallId).
+	// agy updates step rows in place as tools run, so a later poll can observe
+	// the terminal transition and close the tool-call lifecycle (see
+	// `emitToolStepTerminal`).
+	private readonly openToolSteps = new Map<number, string>();
 	// Replay: buffered consecutive agent-text parts, flushed at boundaries.
 	private readonly pendingAgentParts: string[] = [];
 
@@ -94,12 +99,58 @@ export class Translator {
 				if (this.opts.mode === "replay") {
 					this.flushAgentBuffer(out);
 				} else if (this.emittedSteps.has(row.idx)) {
+					// agy moves a step's status in place (same idx) as its tool runs,
+					// and every poll re-reads the whole turn — so a tool step that was
+					// first emitted mid-run may have reached a terminal state since.
+					// Re-emit it as tool_call_update so clients can close the
+					// tool-call lifecycle; without this, such a step stays
+					// in_progress forever.
+					this.emitToolStepTerminal(row, out);
 					return;
 				}
 				this.emittedSteps.add(row.idx);
-				this.pushDispatched(row, out);
+				for (const update of this.dispatchStep(row)) {
+					out.push(update);
+					this.trackOpenToolStep(row.idx, update);
+				}
 			}
 		}
+	}
+
+	/**
+	 * Remember tool-call updates emitted with a non-terminal status, so a later
+	 * poll can close them once agy reports the outcome. Terminal tool calls and
+	 * non-tool updates need no tracking.
+	 */
+	private trackOpenToolStep(idx: number, update: SessionUpdate): void {
+		if (this.opts.mode !== "stream") return;
+		if (update.sessionUpdate !== "tool_call") return;
+		// An absent status means in_progress per the ACP spec.
+		if (update.status === "completed" || update.status === "failed") return;
+		this.openToolSteps.set(idx, update.toolCallId);
+	}
+
+	/**
+	 * Re-build the update for an already-emitted tool step and emit it as
+	 * tool_call_update when agy has since moved it to a terminal state. Steps
+	 * still in flight are suppressed — only the terminal transition is worth a
+	 * notification.
+	 */
+	private emitToolStepTerminal(row: StepRow, out: SessionUpdate[]): void {
+		if (!this.openToolSteps.has(row.idx)) return;
+		for (const update of this.dispatchStep(row)) {
+			if (update.sessionUpdate !== "tool_call") continue;
+			if (update.status !== "completed" && update.status !== "failed") continue;
+			out.push({ ...update, sessionUpdate: "tool_call_update" });
+			this.openToolSteps.delete(row.idx);
+		}
+	}
+
+	/** Build the ACP updates for one step via the per-step-type dispatchers. */
+	private dispatchStep(row: StepRow): SessionUpdate[] {
+		const update = buildUpdatefromStepPayload(row, this.opts.cwd);
+		if (Array.isArray(update)) return update;
+		return update ? [update] : [];
 	}
 
 	private pushDispatched(row: StepRow, out: SessionUpdate[]): void {

--- a/tests/conversation/translator.test.ts
+++ b/tests/conversation/translator.test.ts
@@ -7,16 +7,39 @@ function mockStep(
 	idx: number,
 	stepType: number,
 	payloadObj: any = {},
+	status = 0,
 ): StepRow {
 	return {
 		idx,
 		stepType,
-		status: 0,
+		status,
 		stepPayload: payloadObj,
 		error: null,
 		permission: null,
 		task: null,
 	} as any;
+}
+
+function mockRunCommandStep(
+	idx: number,
+	callId: string,
+	status: number,
+): StepRow {
+	return mockStep(
+		idx,
+		21,
+		{
+			toolRun: {
+				call: {
+					callId,
+					namePrimary: "run_command",
+					rawInputJson: '{"CommandLine":"echo hi","Cwd":"/tmp"}',
+				},
+				titlePrimary: "Run echo hi",
+			},
+		},
+		status,
+	);
 }
 
 describe("conversation/translator", () => {
@@ -55,6 +78,55 @@ describe("conversation/translator", () => {
 				mockStep(2, 8, { toolRun: { call: { namePrimary: "view_file" } } }), // same idx
 			]);
 			expect(updates2.length).toBe(0);
+		});
+
+		test("closes an in-flight tool call once agy reports completion", () => {
+			const translator = new Translator({
+				mode: "stream",
+				skipNarration: false,
+			});
+
+			// First poll: step still running (agy status 2 → in_progress).
+			const updates1 = translator.translate([mockRunCommandStep(3, "call_1", 2)]);
+			expect(updates1.length).toBe(1);
+			expect(updates1[0].sessionUpdate).toBe("tool_call");
+			expect((updates1[0] as any).status).toBe("in_progress");
+			expect((updates1[0] as any).toolCallId).toBe("call_1");
+
+			// Later poll: same row, agy has marked it completed (status 3).
+			const updates2 = translator.translate([mockRunCommandStep(3, "call_1", 3)]);
+			expect(updates2.length).toBe(1);
+			expect(updates2[0].sessionUpdate).toBe("tool_call_update");
+			expect((updates2[0] as any).status).toBe("completed");
+			expect((updates2[0] as any).toolCallId).toBe("call_1");
+
+			// Yet another poll of the now-terminal row: nothing more to send.
+			const updates3 = translator.translate([mockRunCommandStep(3, "call_1", 3)]);
+			expect(updates3.length).toBe(0);
+		});
+
+		test("closes an in-flight tool call that agy reports as failed", () => {
+			const translator = new Translator({
+				mode: "stream",
+				skipNarration: false,
+			});
+
+			translator.translate([mockRunCommandStep(4, "call_2", 2)]);
+			const updates = translator.translate([mockRunCommandStep(4, "call_2", 7)]);
+			expect(updates.length).toBe(1);
+			expect(updates[0].sessionUpdate).toBe("tool_call_update");
+			expect((updates[0] as any).status).toBe("failed");
+		});
+
+		test("stays silent while an in-flight tool call is still running", () => {
+			const translator = new Translator({
+				mode: "stream",
+				skipNarration: false,
+			});
+
+			translator.translate([mockRunCommandStep(5, "call_3", 2)]);
+			const updates = translator.translate([mockRunCommandStep(5, "call_3", 2)]);
+			expect(updates.length).toBe(0);
 		});
 
 		test("filters narration in stream mode", () => {


### PR DESCRIPTION

## Problem

`agy` updates step rows in place (same `idx`) as their tools run, and the
stream poller re-reads the whole turn on every tick. But the `Translator`
deduplicated tool steps by `idx` and never looked at an already-emitted step
again, so a tool step first polled while still running was emitted as a single
`tool_call` with `status: "in_progress"` and **never** received a terminal
update. The bridge never sends `tool_call_update` at all.

This violates the ACP tool-call lifecycle (a non-terminal `tool_call` must
eventually receive a terminal update) and breaks ACP clients that treat
end-of-turn with open tool calls as a truncated turn. Concretely: in a real
quartet session, 25 of 57 tool calls in one turn were caught mid-run and stayed
`in_progress` forever, so the client failed the whole prompt with
`end_turn with unfinished tool call(s)` and dropped ~40% of the tool results
from the persisted conversation.

## Fix

Track tool steps emitted with a non-terminal status (`openToolSteps`). On later
polls, when an already-emitted tool step is seen again with a terminal status,
re-emit it as `tool_call_update` (same tool call id, plus the final
title/kind/content/locations/rawInput/rawOutput) and stop tracking it. Steps
still in flight stay silent, and steps first seen terminal are unaffected.

The replay path is unchanged: it reads each row once with its final status.

## Validation

- `bun run typecheck` and `bun test` pass (199 tests, incl. 4 new ones covering
  the completed / failed / still-running / already-terminal transitions).
- Replayed the real agy conversation DB that produced the failure
  (`conversations/<id>.db`, 57 tool steps): first poll with all steps caught
  mid-run, second poll with the final in-place-updated statuses → the fixed
  translator emits exactly 57 `tool_call_update`s (57 distinct ids, all
  terminal), and a third poll is clean.
